### PR TITLE
Added methods for verification of signatures

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,15 +50,4 @@
     </dependency>
   </dependencies>
 
-<build><pluginManagement><plugins>
-<plugin>
-  <groupId>org.apache.maven.plugins</groupId>
-  <artifactId>maven-surefire-plugin</artifactId>
-  <version>2.16</version>
-  <configuration>
-    <redirectTestOutputToFile>true</redirectTestOutputToFile>
-  </configuration>
-</plugin>
-</plugins></pluginManagement></build>
-
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 
   <artifactId>tomitribe-http-signatures</artifactId>
   <packaging>jar</packaging>
-  <version>1.1-SNAPSHOT</version>
+  <version>1.2-SNAPSHOT</version>
   <name>Tomitribe :: HTTP Signatures</name>
 
   <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -50,4 +50,15 @@
     </dependency>
   </dependencies>
 
+<build><pluginManagement><plugins>
+<plugin>
+  <groupId>org.apache.maven.plugins</groupId>
+  <artifactId>maven-surefire-plugin</artifactId>
+  <version>2.16</version>
+  <configuration>
+    <redirectTestOutputToFile>true</redirectTestOutputToFile>
+  </configuration>
+</plugin>
+</plugins></pluginManagement></build>
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 
   <artifactId>tomitribe-http-signatures</artifactId>
   <packaging>jar</packaging>
-  <version>1.2-SNAPSHOT</version>
+  <version>1.1-SNAPSHOT</version>
   <name>Tomitribe :: HTTP Signatures</name>
 
   <scm>

--- a/src/main/java/org/tomitribe/auth/signatures/Verifier.java
+++ b/src/main/java/org/tomitribe/auth/signatures/Verifier.java
@@ -18,24 +18,19 @@ package org.tomitribe.auth.signatures;
 
 import javax.crypto.Mac;
 import java.io.IOException;
-import java.security.*;
+import java.security.Key;
+import java.security.NoSuchAlgorithmException;
+import java.security.PublicKey;
+import java.security.Provider;
+import java.security.SignatureException;
 import java.util.Arrays;
 import java.util.Map;
 
 import static java.util.Objects.requireNonNull;
 
 /**
- * It is an intentional part of the design that the same Signer instance
+ * It is an intentional part of the design that the same Verifier instance
  * can be reused on several HTTP Messages in a multi-threaded fashion
- *
- * <p>
- * The supplied Signature instance will be used as the basis for all
- * future signatures created from this Signer.
- *
- * <p>
- *  Each call to 'verify' will emit a Signature with the same 'keyId',
- * 'algorithm', 'headers' but a newly calculated 'signature'
- *
  */
 public class Verifier {
 
@@ -144,7 +139,8 @@ public class Verifier {
                 final Mac mac = provider == null ? Mac.getInstance(algorithm.getJmvName()) : Mac.getInstance(algorithm.getJmvName(), provider);
                 mac.init(key);
                 byte[] hash = mac.doFinal(signingStringBytes);
-                return Arrays.equals(hash, signature.getSignature().getBytes());
+                byte[] encoded = Base64.encodeBase64(hash);
+                return Arrays.equals(encoded, signature.getSignature().getBytes());
 
             } catch (NoSuchAlgorithmException e) {
 

--- a/src/main/java/org/tomitribe/auth/signatures/Verifier.java
+++ b/src/main/java/org/tomitribe/auth/signatures/Verifier.java
@@ -1,0 +1,160 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.tomitribe.auth.signatures;
+
+import javax.crypto.Mac;
+import java.io.IOException;
+import java.security.*;
+import java.util.Arrays;
+import java.util.Map;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * It is an intentional part of the design that the same Signer instance
+ * can be reused on several HTTP Messages in a multi-threaded fashion
+ *
+ * <p>
+ * The supplied Signature instance will be used as the basis for all
+ * future signatures created from this Signer.
+ *
+ * <p>
+ *  Each call to 'verify' will emit a Signature with the same 'keyId',
+ * 'algorithm', 'headers' but a newly calculated 'signature'
+ *
+ */
+public class Verifier {
+
+    private final Verify verify;
+    private final Signature signature;
+    private final Algorithm algorithm;
+    private final Provider provider;
+
+    public Verifier(final Key key, final Signature signature) {
+        this(key, signature, null);
+    }
+
+    public Verifier(final Key key, final Signature signature, final Provider provider) {
+        requireNonNull(key, "Key cannot be null");
+        this.signature = requireNonNull(signature, "Signature cannot be null");
+        this.algorithm = signature.getAlgorithm();
+        this.provider = provider;
+
+        if (java.security.Signature.class.equals(algorithm.getType())) {
+
+            this.verify = new Asymmetric(PublicKey.class.cast(key));
+
+        } else if (Mac.class.equals(algorithm.getType())) {
+
+            this.verify = new Symmetric(key);
+
+        } else {
+
+            throw new UnsupportedAlgorithmException(String.format("Unknown Algorithm type %s %s", algorithm.getPortableName(), algorithm.getType().getName()));
+        }
+
+        // check that the JVM really knows the algorithm we are going to use
+        try {
+
+            verify.verify("validation".getBytes());
+
+        } catch (final RuntimeException e) {
+
+            throw (RuntimeException) e;
+
+        } catch (final Exception e) {
+
+            throw new IllegalStateException("Can't initialise the Signer using the provided algorithm and key", e);
+        }
+    }
+
+    public boolean verify(final String method, final String uri, final Map<String, String> headers) throws IOException, NoSuchAlgorithmException, SignatureException {
+
+        final String signingString = createSigningString(method, uri, headers);
+
+        return verify.verify(signingString.getBytes());
+    }
+
+    public String createSigningString(final String method, final String uri, final Map<String, String> headers) throws IOException {
+        return Signatures.createSigningString(signature.getHeaders(), method, uri, headers);
+    }
+
+    private interface Verify {
+        boolean verify(byte[] signingStringBytes);
+    }
+
+    private class Asymmetric implements Verify {
+
+        private final PublicKey key;
+
+        private Asymmetric(final PublicKey key) {
+            this.key = key;
+        }
+
+        @Override
+        public boolean verify(final byte[] signingStringBytes) {
+            try {
+
+                final java.security.Signature instance = provider == null ?
+                        java.security.Signature.getInstance(algorithm.getJmvName()) :
+                        java.security.Signature.getInstance(algorithm.getJmvName(), provider);
+
+                instance.initVerify(key);
+                instance.update(signingStringBytes);
+                return instance.verify(Base64.decodeBase64(signature.getSignature().getBytes()));
+
+            } catch (NoSuchAlgorithmException e) {
+
+                throw new UnsupportedAlgorithmException(algorithm.getJmvName());
+
+            } catch (Exception e) {
+
+                throw new IllegalStateException(e);
+            }
+        }
+    }
+
+    private class Symmetric implements Verify {
+
+        private final Key key;
+
+        private Symmetric(final Key key) {
+            this.key = key;
+        }
+
+        @Override
+        public boolean verify(final byte[] signingStringBytes) {
+
+            try {
+
+                final Mac mac = provider == null ? Mac.getInstance(algorithm.getJmvName()) : Mac.getInstance(algorithm.getJmvName(), provider);
+                mac.init(key);
+                byte[] hash = mac.doFinal(signingStringBytes);
+                return Arrays.equals(hash, signature.getSignature().getBytes());
+
+            } catch (NoSuchAlgorithmException e) {
+
+                throw new UnsupportedAlgorithmException(algorithm.getJmvName());
+
+            } catch (Exception e) {
+
+                throw new IllegalStateException(e);
+
+            }
+        }
+    }
+}

--- a/src/main/java/org/tomitribe/auth/signatures/Verifier.java
+++ b/src/main/java/org/tomitribe/auth/signatures/Verifier.java
@@ -29,8 +29,7 @@ import java.util.Map;
 import static java.util.Objects.requireNonNull;
 
 /**
- * It is an intentional part of the design that the same Verifier instance
- * can be reused on several HTTP Messages in a multi-threaded fashion
+ * A new instance of the Verifier class needs to be created for each signature.
  */
 public class Verifier {
 

--- a/src/test/java/org/tomitribe/auth/signatures/VerifierTest.java
+++ b/src/test/java/org/tomitribe/auth/signatures/VerifierTest.java
@@ -1,0 +1,281 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.tomitribe.auth.signatures;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.security.Key;
+import java.security.Provider;
+import java.util.HashMap;
+import java.util.Map;
+
+public class VerifierTest extends Assert {
+
+    @Test(expected = IllegalStateException.class)
+    public void validVerifier() {
+        final Signature signature = new Signature("hmac-key-1", "hmac-sha256", null, "content-length", "host", "date", "(request-target)");
+        final Key key = new SecretKeySpec("don't tell".getBytes(), "HmacSHA256");
+        new Verifier(key, signature);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void nullKey() {
+        final Signature signature = new Signature("hmac-key-1", "hmac-sha256", null, "content-length", "host", "date", "(request-target)");
+        new Verifier(null, signature);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void nullSignature() {
+        final Key key = new SecretKeySpec("don't tell".getBytes(), "HmacSHA256");
+        new Verifier(key, null);
+    }
+
+    @Test(expected = UnsupportedAlgorithmException.class)
+    public void unsupportedAlgorithm() {
+        final Signature signature = new Signature("hmac-key-1", "should fail because of this", null, "content-length", "host", "date", "(request-target)");
+        final Key key = new SecretKeySpec("don't tell".getBytes(), "HmacSHA256");
+        new Verifier(key, signature);
+    }
+
+    @Test(expected = UnsupportedAlgorithmException.class)
+    public void algoNotImplemented() {
+        final Provider p = new Provider("Tribe", 1.0, "Only for mock") {{
+            clear();
+        }};
+
+        final Signature signature = new Signature("hmac-key-1", "hmac-sha256", null, "content-length", "host", "date", "(request-target)");
+        final Key key = new SecretKeySpec("don't tell".getBytes(), "HmacSHA256");
+        new Verifier(key, signature, p);
+    }
+
+    /**
+     * It is an intentional part of the design that the same Signer instance
+     * can be reused on several HTTP Messages in a multi-threaded fashion
+     * <p/>
+     * Reuse is tested here
+     * <p/>
+     * TODO test threading
+     */
+    @Test
+    public void testVerify() throws Exception {
+
+        final String authorization = "Signature keyId=\"hmac-key-1\",algorithm=\"hmac-sha256\",headers=\"content-length host date (request-target)\",signature=\"yT/NrPI9mKB5R7FTLRyFWvB+QLQOEAvbGmauC0tI+Jg=\"";
+        final Signature signature = Signature.fromString(authorization);
+
+        final Key key = new SecretKeySpec("don't tell".getBytes(), "HmacSHA256");
+        final Verifier verifier = new Verifier(key, signature);
+
+        {
+            final String method = "GET";
+            final String uri = "/foo/Bar";
+            final Map<String, String> headers = new HashMap<String, String>();
+            headers.put("Host", "example.org");
+            headers.put("Date", "Tue, 07 Jun 2014 20:51:35 GMT");
+            headers.put("Content-Type", "application/json");
+            headers.put("Digest", "SHA-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=");
+            headers.put("Accept", "*/*");
+            headers.put("Content-Length", "18");
+            boolean verifies = verifier.verify(method, uri, headers);
+            assertTrue(verifies);
+        }
+
+        { // method changed.  should get a different signature
+            final String method = "PUT";
+            final String uri = "/foo/Bar";
+            final Map<String, String> headers = new HashMap<String, String>();
+            headers.put("Host", "example.org");
+            headers.put("Date", "Tue, 07 Jun 2014 20:51:35 GMT");
+            headers.put("Content-Type", "application/json");
+            headers.put("Digest", "SHA-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=");
+            headers.put("Accept", "*/*");
+            headers.put("Content-Length", "18");
+            boolean verifies = verifier.verify(method, uri, headers);
+            assertFalse(verifies);
+        }
+
+        { // only Digest changed.  not part of the signature, should have no effect
+            final String method = "GET";
+            final String uri = "/foo/Bar";
+            final Map<String, String> headers = new HashMap<String, String>();
+            headers.put("Host", "example.org");
+            headers.put("Date", "Tue, 07 Jun 2014 20:51:35 GMT");
+            headers.put("Content-Type", "application/json");
+            headers.put("Digest", "SHA-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu8DBPE=");
+            headers.put("Accept", "*/*");
+            headers.put("Content-Length", "18");
+            boolean verifies = verifier.verify(method, uri, headers);
+            assertTrue(verifies);
+        }
+
+        { // uri changed.  should get a different signature
+            final String method = "GET";
+            final String uri = "/foo/bar";
+            final Map<String, String> headers = new HashMap<String, String>();
+            headers.put("Host", "example.org");
+            headers.put("Date", "Tue, 07 Jun 2014 20:51:35 GMT");
+            headers.put("Content-Type", "application/json");
+            headers.put("Digest", "SHA-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu8DBPE=");
+            headers.put("Accept", "*/*");
+            headers.put("Content-Length", "18");
+            boolean verifies = verifier.verify(method, uri, headers);
+            assertFalse(verifies);
+        }
+    }
+
+    @Test
+    public void defaultHeaderList() throws Exception {
+        final String authorization = "Signature keyId=\"hmac-key-1\",algorithm=\"hmac-sha256\",headers=\"date\",signature=\"WbB9VXuVdRt1LKQ5mDuT+tiaChn8R7WhdAWAY1lhKZQ=\"";
+        final Signature signature = Signature.fromString(authorization);
+
+        final Key key = new SecretKeySpec("don't tell".getBytes(), "HmacSHA256");
+        final Verifier verifier = new Verifier(key, signature);
+
+        { // just date should be required
+            final Map<String, String> headers = new HashMap<String, String>();
+            headers.put("Date", "Tue, 07 Jun 2014 20:51:35 GMT");
+
+            boolean verifies = verifier.verify("GET", "/foo/Bar", headers);
+            assertTrue(verifies);
+        }
+
+        { // adding other headers shouldn't matter
+            final Map<String, String> headers = new HashMap<String, String>();
+            headers.put("Date", "Tue, 07 Jun 2014 20:51:35 GMT");
+            headers.put("Content-Type", "application/json");
+            headers.put("Digest", "SHA-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu8DBPE=");
+            headers.put("Accept", "*/*");
+            headers.put("Content-Length", "18");
+
+            boolean verifies = verifier.verify("GET", "/foo/Bar", headers);
+            assertTrue(verifies);
+        }
+    }
+
+    @Test(expected = MissingRequiredHeaderException.class)
+    public void missingDefaultHeader() throws Exception {
+        final String authorization = "Signature keyId=\"hmac-key-1\",algorithm=\"hmac-sha256\",headers=\"\",signature=\"WbB9VXuVdRt1LKQ5mDuT+tiaChn8R7WhdAWAY1lhKZQ=\"";
+        final Signature signature = Signature.fromString(authorization);
+
+        final Key key = new SecretKeySpec("don't tell".getBytes(), "HmacSHA256");
+        final Verifier verifier = new Verifier(key, signature);
+
+        final Map<String, String> headers = new HashMap<String, String>();
+        verifier.verify("GET", "/foo/Bar", headers);
+    }
+
+    @Test(expected = MissingRequiredHeaderException.class)
+    public void missingExplicitHeader() throws Exception {
+        final String authorization = "Signature keyId=\"hmac-key-1\",algorithm=\"hmac-sha256\",headers=\"date accept\",signature=\"WbB9VXuVdRt1LKQ5mDuT+tiaChn8R7WhdAWAY1lhKZQ=\"";
+        final Signature signature = Signature.fromString(authorization);
+
+        final Key key = new SecretKeySpec("don't tell".getBytes(), "HmacSHA256");
+        final Verifier verifier = new Verifier(key, signature);
+
+        final Map<String, String> headers = new HashMap<String, String>();
+        headers.put("Date", "Tue, 07 Jun 2014 20:51:36 GMT");
+        verifier.verify("GET", "/foo/Bar", headers);
+    }
+
+    @Test
+    public void testVerify1() throws Exception {
+        final String authorization = "Signature keyId=\"hmac-key-1\",algorithm=\"hmac-sha256\",headers=\"content-length host date (request-target)\",signature=\"yT/NrPI9mKB5R7FTLRyFWvB+QLQOEAvbGmauC0tI+Jg=\"";
+        final Signature signature = Signature.fromString(authorization);
+
+        final Key key = new SecretKeySpec("don't tell".getBytes(), "HmacSHA256");
+        final Verifier verifier = new Verifier(key, signature);
+
+        //final Signature signature = new Signature("hmac-key-1", "hmac-sha256", null, "content-length", "host", "date", "(request-target)");
+
+        final Map<String, String> headers = new HashMap<String, String>();
+        headers.put("Host", "example.org");
+        headers.put("Date", "Tue, 07 Jun 2014 20:51:35 GMT");
+        headers.put("Content-Type", "application/json");
+        headers.put("Digest", "SHA-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=");
+        headers.put("Accept", "*/*");
+        headers.put("Content-Length", "18");
+
+        { // Assert the Signing String
+
+            final String signingString = "" +
+                    "content-length: 18\n" +
+                    "host: example.org\n" +
+                    "date: Tue, 07 Jun 2014 20:51:35 GMT\n" +
+                    "(request-target): get /foo/Bar";
+
+            assertEquals(signingString, verifier.createSigningString("GET", "/foo/Bar", headers));
+        }
+
+    }
+
+    @Test
+    public void testCreateSingingString() throws Exception {
+        {
+            final String method = "POST";
+            final String uri = "/foo";
+            final Map<String, String> headers = new HashMap<String, String>();
+            headers.put("Host", "example.org");
+            headers.put("Date", "Tue, 07 Jun 2014 20:51:35 GMT");
+            headers.put("Content-Type", "application/json");
+            headers.put("Digest", "SHA-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=");
+            headers.put("Accept", "*/*");
+            headers.put("Content-Length", "18");
+
+            final String authorization = "Signature keyId=\"hmac-key-1\",algorithm=\"hmac-sha256\",headers=\"(request-target) host date digest content-length\",signature=\"yT/NrPI9mKB5R7FTLRyFWvB+QLQOEAvbGmauC0tI+Jg=\"";
+            final Signature signature = Signature.fromString(authorization);
+
+            final Key key = new SecretKeySpec("don't tell".getBytes(), "HmacSHA256");
+            final Verifier verifier = new Verifier(key, signature);
+
+            final String string = verifier.createSigningString(method, uri, headers);
+            assertEquals("(request-target): post /foo\n" +
+                    "host: example.org\n" +
+                    "date: Tue, 07 Jun 2014 20:51:35 GMT\n" +
+                    "digest: SHA-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=\n" +
+                    "content-length: 18", string);
+        }
+
+        {
+            final String method = "GET";
+            final String uri = "/foo/Bar";
+            final Map<String, String> headers = new HashMap<String, String>();
+            headers.put("Host", "example.org");
+            headers.put("Date", "Tue, 07 Jun 2014 20:51:35 GMT");
+            headers.put("Content-Type", "application/json");
+            headers.put("Digest", "SHA-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=");
+            headers.put("Accept", "*/*");
+            headers.put("Content-Length", "18");
+
+            final String authorization = "Signature keyId=\"hmac-key-1\",algorithm=\"hmac-sha256\",headers=\"content-length host date (request-target)\",signature=\"yT/NrPI9mKB5R7FTLRyFWvB+QLQOEAvbGmauC0tI+Jg=\"";
+            final Signature signature = Signature.fromString(authorization);
+
+            final Key key = new SecretKeySpec("don't tell".getBytes(), "HmacSHA256");
+            final Verifier verifier = new Verifier(key, signature);
+
+            final String string = verifier.createSigningString(method, uri, headers);
+            assertEquals("content-length: 18\n" +
+                    "host: example.org\n" +
+                    "date: Tue, 07 Jun 2014 20:51:35 GMT\n" +
+                    "(request-target): get /foo/Bar"
+                    , string);
+        }
+    }
+
+
+}


### PR DESCRIPTION
The verification code is similar to the original signing code, including tests. It seems to be working nicely with both symmetric and asymmetric crypto.

Example of basic usage with RSA:
```
HttpServletRequest request;
String authorization = request.getHeader("authorization");
Signature signature = Signature.fromString(authorization);
RSAPublicKey publicKey = ...
final Verifier verifier = new Verifier(publicKey, signature);
boolean verifies = verifier.verify(request.getMethod().toLowerCase(), request.getRequestURI(), headers);
```