### PR TITLE
Support for keyId values containing commas

### DIFF
--- a/src/main/java/org/tomitribe/auth/signatures/Signature.java
+++ b/src/main/java/org/tomitribe/auth/signatures/Signature.java
@@ -22,6 +22,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class Signature {
 
@@ -135,17 +137,13 @@ public class Signature {
         try {
             authorization = normalize(authorization);
 
-            final String[] split = authorization.split(",");
-
             final Map<String, String> map = new HashMap<String, String>();
 
-            for (String s : split) {
-                s = s.trim();
-                final int i = s.indexOf("=\"");
-
-                final String key = s.substring(0, i).toLowerCase();
-                final String value = s.substring(i + 2, s.length() - 1);
-
+            final Pattern rfc2617Param = Pattern.compile("(\\w+)=\"([^\"]*)\"");
+            final Matcher matcher = rfc2617Param.matcher(authorization);
+            while (matcher.find()) {
+                final String key = matcher.group(1).toLowerCase();
+                final String value = matcher.group(2);
                 map.put(key, value);
             }
 

--- a/src/test/java/org/tomitribe/auth/signatures/SignatureTest.java
+++ b/src/test/java/org/tomitribe/auth/signatures/SignatureTest.java
@@ -83,6 +83,17 @@ public class SignatureTest {
                 "content-length", join("\n", signature.getHeaders()));
     }
 
+    @Test
+    public void testFromStringWithLdapDNKeyId() throws Exception {
+        String authorization = "Signature keyId=\"UID=jsmith,DC=example,DC=net\",algorithm=\"hmac-sha256\",\n" +
+                "   headers=\"(request-target) host date digest content-length\",\n" +
+                "   signature=\"yT/NrPI9mKB5R7FTLRyFWvB+QLQOEAvbGmauC0tI+Jg=\"";
+
+        final Signature signature = Signature.fromString(authorization);
+
+        assertEquals("UID=jsmith,DC=example,DC=net", signature.getKeyId());
+    }
+
     /**
      * Authorization header parameters (keyId, algorithm, headers, signature)
      * may legally not include 'headers'


### PR DESCRIPTION
Original implementation of Signature.fromString did not take into
account the possiblity of keyId containing commas (e.g. if the
value is an LDAP DN). Replaces parsing with a regular expression.