### PR TITLE
Avoid NPE if method is null

### DIFF
--- a/src/main/java/org/tomitribe/auth/signatures/Signatures.java
+++ b/src/main/java/org/tomitribe/auth/signatures/Signatures.java
@@ -25,13 +25,13 @@ public enum Signatures {
     ;
 
     public static String createSigningString(final List<String> required, String method, final String uri, Map<String, String> headers) {
-        method = lowercase(method);
         headers = lowercase(headers);
 
         final List<String> list = new ArrayList<String>(required.size());
 
         for (final String key : required) {
             if ("(request-target)".equals(key)) {
+                method = lowercase(method);
                 list.add(Join.join(" ", "(request-target):", method, uri));
 
             } else {


### PR DESCRIPTION
For signature response messages, we don't have a method (and URI), but the code forces us to supply a non null method or it throws an NPE