### PR TITLE
Fix field name typo, add maven-compiler-plugin in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,23 @@
     </license>
   </licenses>
 
-  <properties>
+  <build>
+    <sourceDirectory>src/main/java</sourceDirectory>
+    <outputDirectory>target/classes</outputDirectory>
+    <plugins>
+       <plugin>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <version>3.8.1</version>
+            <configuration>
+                <source>1.8</source>
+                <target>1.8</target>
+            </configuration>
+       </plugin>
+    </plugins>
+  </build>
+
+
+<properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 

--- a/src/main/java/org/tomitribe/auth/signatures/Algorithm.java
+++ b/src/main/java/org/tomitribe/auth/signatures/Algorithm.java
@@ -29,7 +29,7 @@ public enum Algorithm {
     HMAC_SHA384("HmacSHA384", "hmac-sha384", Mac.class),
     HMAC_SHA512("HmacSHA512", "hmac-sha512", Mac.class),
 
-    // rsa
+    // RSA PKCS#1 v1.5 signature
     RSA_SHA1("SHA1withRSA", "rsa-sha1", java.security.Signature.class),
     RSA_SHA256("SHA256withRSA", "rsa-sha256", java.security.Signature.class),
     RSA_SHA384("SHA384withRSA", "rsa-sha384", java.security.Signature.class),
@@ -51,18 +51,19 @@ public enum Algorithm {
 
     static {
         for (final Algorithm algorithm : Algorithm.values()) {
-            aliases.put(normalize(algorithm.getJmvName()), algorithm);
+            aliases.put(normalize(algorithm.getJvmName()), algorithm);
             aliases.put(normalize(algorithm.getPortableName()), algorithm);
         }
     }
 
     private final String portableName;
-    private final String jmvName;
+    // The algorithm name passed to java.security.Signature or Mac.class.
+    private final String jvmName;
     private final Class type;
 
-    Algorithm(final String jmvName, final String portableName, final Class type) {
+    Algorithm(final String jvmName, final String portableName, final Class type) {
         this.portableName = portableName;
-        this.jmvName = jmvName;
+        this.jvmName = jvmName;
         this.type = type;
     }
 
@@ -70,8 +71,8 @@ public enum Algorithm {
         return portableName;
     }
 
-    public String getJmvName() {
-        return jmvName;
+    public String getJvmName() {
+        return jvmName;
     }
 
     public Class getType() {
@@ -83,7 +84,7 @@ public enum Algorithm {
     }
 
     public static String toJvmName(final String name) {
-        return get(name).getJmvName();
+        return get(name).getJvmName();
     }
 
     public static Algorithm get(String name) {

--- a/src/main/java/org/tomitribe/auth/signatures/Signer.java
+++ b/src/main/java/org/tomitribe/auth/signatures/Signer.java
@@ -118,8 +118,8 @@ public class Signer {
             try {
 
                 final java.security.Signature instance = provider == null ?
-                        java.security.Signature.getInstance(algorithm.getJmvName()) :
-                        java.security.Signature.getInstance(algorithm.getJmvName(), provider);
+                        java.security.Signature.getInstance(algorithm.getJvmName()) :
+                        java.security.Signature.getInstance(algorithm.getJvmName(), provider);
 
                 instance.initSign(key);
                 instance.update(signingStringBytes);
@@ -127,7 +127,7 @@ public class Signer {
 
             } catch (NoSuchAlgorithmException e) {
 
-                throw new UnsupportedAlgorithmException(algorithm.getJmvName());
+                throw new UnsupportedAlgorithmException(algorithm.getJvmName());
 
             } catch (Exception e) {
 
@@ -149,13 +149,13 @@ public class Signer {
 
             try {
 
-                final Mac mac = provider == null ? Mac.getInstance(algorithm.getJmvName()) : Mac.getInstance(algorithm.getJmvName(), provider);
+                final Mac mac = provider == null ? Mac.getInstance(algorithm.getJvmName()) : Mac.getInstance(algorithm.getJvmName(), provider);
                 mac.init(key);
                 return mac.doFinal(signingStringBytes);
 
             } catch (NoSuchAlgorithmException e) {
 
-                throw new UnsupportedAlgorithmException(algorithm.getJmvName());
+                throw new UnsupportedAlgorithmException(algorithm.getJvmName());
 
             } catch (Exception e) {
 

--- a/src/main/java/org/tomitribe/auth/signatures/Verifier.java
+++ b/src/main/java/org/tomitribe/auth/signatures/Verifier.java
@@ -104,8 +104,8 @@ public class Verifier {
             try {
 
                 final java.security.Signature instance = provider == null ?
-                        java.security.Signature.getInstance(algorithm.getJmvName()) :
-                        java.security.Signature.getInstance(algorithm.getJmvName(), provider);
+                        java.security.Signature.getInstance(algorithm.getJvmName()) :
+                        java.security.Signature.getInstance(algorithm.getJvmName(), provider);
 
                 instance.initVerify(key);
                 instance.update(signingStringBytes);
@@ -113,7 +113,7 @@ public class Verifier {
 
             } catch (NoSuchAlgorithmException e) {
 
-                throw new UnsupportedAlgorithmException(algorithm.getJmvName());
+                throw new UnsupportedAlgorithmException(algorithm.getJvmName());
 
             } catch (Exception e) {
 
@@ -135,7 +135,7 @@ public class Verifier {
 
             try {
 
-                final Mac mac = provider == null ? Mac.getInstance(algorithm.getJmvName()) : Mac.getInstance(algorithm.getJmvName(), provider);
+                final Mac mac = provider == null ? Mac.getInstance(algorithm.getJvmName()) : Mac.getInstance(algorithm.getJvmName(), provider);
                 mac.init(key);
                 byte[] hash = mac.doFinal(signingStringBytes);
                 byte[] encoded = Base64.encodeBase64(hash);
@@ -143,7 +143,7 @@ public class Verifier {
                 return MessageDigest.isEqual(encoded, signature.getSignature().getBytes());
             } catch (NoSuchAlgorithmException e) {
 
-                throw new UnsupportedAlgorithmException(algorithm.getJmvName());
+                throw new UnsupportedAlgorithmException(algorithm.getJvmName());
 
             } catch (Exception e) {
 

--- a/src/test/java/org/tomitribe/auth/signatures/AlgorithmTest.java
+++ b/src/test/java/org/tomitribe/auth/signatures/AlgorithmTest.java
@@ -45,22 +45,22 @@ public class AlgorithmTest extends Assert {
 
     @Test
     public void jvmNames() {
-        assertEquals("HmacSHA1", HMAC_SHA1.getJmvName());
-        assertEquals("HmacSHA224", HMAC_SHA224.getJmvName());
-        assertEquals("HmacSHA256", HMAC_SHA256.getJmvName());
-        assertEquals("HmacSHA384", HMAC_SHA384.getJmvName());
-        assertEquals("HmacSHA512", HMAC_SHA512.getJmvName());
-        assertEquals("SHA1withRSA", RSA_SHA1.getJmvName());
-        assertEquals("SHA256withRSA", RSA_SHA256.getJmvName());
-        assertEquals("SHA384withRSA", RSA_SHA384.getJmvName());
-        assertEquals("SHA512withRSA", RSA_SHA512.getJmvName());
-        assertEquals("SHA1withDSA", DSA_SHA1.getJmvName());
-        assertEquals("SHA224withDSA", DSA_SHA224.getJmvName());
-        assertEquals("SHA256withDSA", DSA_SHA256.getJmvName());
-        assertEquals("SHA1withECDSA", ECDSA_SHA1.getJmvName());
-        assertEquals("SHA256withECDSA", ECDSA_SHA256.getJmvName());
-        assertEquals("SHA384withECDSA", ECDSA_SHA384.getJmvName());
-        assertEquals("SHA512withECDSA", ECDSA_SHA512.getJmvName());
+        assertEquals("HmacSHA1", HMAC_SHA1.getJvmName());
+        assertEquals("HmacSHA224", HMAC_SHA224.getJvmName());
+        assertEquals("HmacSHA256", HMAC_SHA256.getJvmName());
+        assertEquals("HmacSHA384", HMAC_SHA384.getJvmName());
+        assertEquals("HmacSHA512", HMAC_SHA512.getJvmName());
+        assertEquals("SHA1withRSA", RSA_SHA1.getJvmName());
+        assertEquals("SHA256withRSA", RSA_SHA256.getJvmName());
+        assertEquals("SHA384withRSA", RSA_SHA384.getJvmName());
+        assertEquals("SHA512withRSA", RSA_SHA512.getJvmName());
+        assertEquals("SHA1withDSA", DSA_SHA1.getJvmName());
+        assertEquals("SHA224withDSA", DSA_SHA224.getJvmName());
+        assertEquals("SHA256withDSA", DSA_SHA256.getJvmName());
+        assertEquals("SHA1withECDSA", ECDSA_SHA1.getJvmName());
+        assertEquals("SHA256withECDSA", ECDSA_SHA256.getJvmName());
+        assertEquals("SHA384withECDSA", ECDSA_SHA384.getJvmName());
+        assertEquals("SHA512withECDSA", ECDSA_SHA512.getJvmName());
     }
 
     @Test
@@ -73,15 +73,15 @@ public class AlgorithmTest extends Assert {
     @Test
     public void getWithJvmName() throws Exception {
         for (final Algorithm algorithm : Algorithm.values()) {
-            assertEquals(algorithm, Algorithm.get(algorithm.getJmvName()));
+            assertEquals(algorithm, Algorithm.get(algorithm.getJvmName()));
         }
     }
 
     @Test
     public void getNotCaseSensitive() throws Exception {
         for (final Algorithm algorithm : Algorithm.values()) {
-            assertEquals(algorithm, Algorithm.get(algorithm.getJmvName().toLowerCase()));
-            assertEquals(algorithm, Algorithm.get(algorithm.getJmvName().toUpperCase()));
+            assertEquals(algorithm, Algorithm.get(algorithm.getJvmName().toLowerCase()));
+            assertEquals(algorithm, Algorithm.get(algorithm.getJvmName().toUpperCase()));
 
             assertEquals(algorithm, Algorithm.get(algorithm.getPortableName().toLowerCase()));
             assertEquals(algorithm, Algorithm.get(algorithm.getPortableName().toUpperCase()));
@@ -92,7 +92,7 @@ public class AlgorithmTest extends Assert {
     public void nonAlphaNumericsIgnored() throws Exception {
         for (final Algorithm algorithm : Algorithm.values()) {
             assertEquals(algorithm, Algorithm.get(algorithm.getPortableName().replace("-", " :-./ ")));
-            assertEquals(algorithm, Algorithm.get(algorithm.getJmvName().replace("with", " -/with:.")));
+            assertEquals(algorithm, Algorithm.get(algorithm.getJvmName().replace("with", " -/with:.")));
         }
     }
 

--- a/src/test/java/org/tomitribe/auth/signatures/HmacTest.java
+++ b/src/test/java/org/tomitribe/auth/signatures/HmacTest.java
@@ -98,7 +98,7 @@ public class HmacTest extends Assert {
     private void assertSignature(final Algorithm algorithm, final String expected, final String keyString, final String... sign) throws Exception {
 
         final Signer signer = new Signer(
-                new SecretKeySpec(keyString.getBytes(), algorithm.getJmvName()),
+                new SecretKeySpec(keyString.getBytes(), algorithm.getJvmName()),
                 new Signature("foo-key-1", algorithm, null, sign)
         );
 


### PR DESCRIPTION
1. Fix typo in field name, was jmv instead of jvm.
1. I have added the maven-compiler-plugin in pom.xml. This sets the version of the JVM to 1.8.

Otherwise with mvn 3.8.1, I see a compilation error, mvn tries to use 1.6 by default, which is no longer supported:
```
[ERROR] COMPILATION ERROR : 
[INFO] -------------------------------------------------------------
[ERROR] Source option 6 is no longer supported. Use 7 or later.
[ERROR] Target option 6 is no longer supported. Use 7 or later.
```
From the mvn doc: Also note that at present the default source setting is 1.6 and the default target setting is 1.6, independently of the JDK you run Maven with. You are highly encouraged to change these defaults by setting source and target as described in Setting the -source and -target of the Java Compiler.