### PR TITLE
Add support for RSA-PSS signature algorithm

### DIFF
--- a/src/main/java/org/tomitribe/auth/signatures/Algorithm.java
+++ b/src/main/java/org/tomitribe/auth/signatures/Algorithm.java
@@ -35,6 +35,11 @@ public enum Algorithm {
     RSA_SHA384("SHA384withRSA", "rsa-sha384", java.security.Signature.class),
     RSA_SHA512("SHA512withRSA", "rsa-sha512", java.security.Signature.class),
 
+    // RSA PSS signature
+    // This algorithm requires parameter. For example:
+    // new PSSParameterSpec("SHA-256", "MGF1", MGF1ParameterSpec.SHA256, 32, 1)
+    RSA_PSS("RSASSA-PSS", "rsassa-pss", java.security.Signature.class),
+
     // dsa
     DSA_SHA1("SHA1withDSA", "dsa-sha1", java.security.Signature.class),
     DSA_SHA224("SHA224withDSA", "dsa-sha224", java.security.Signature.class),

--- a/src/main/java/org/tomitribe/auth/signatures/Signer.java
+++ b/src/main/java/org/tomitribe/auth/signatures/Signer.java
@@ -94,7 +94,7 @@ public class Signer {
 
         final String signedAndEncodedString = new String(encoded, "UTF-8");
 
-        return new Signature(signature.getKeyId(), signature.getAlgorithm(), signedAndEncodedString, signature.getHeaders());
+        return new Signature(signature.getKeyId(), signature.getAlgorithm(), signature.getParameterSpec(), signedAndEncodedString, signature.getHeaders());
     }
 
     public String createSigningString(final String method, final String uri, final Map<String, String> headers) throws IOException {
@@ -120,7 +120,9 @@ public class Signer {
                 final java.security.Signature instance = provider == null ?
                         java.security.Signature.getInstance(algorithm.getJvmName()) :
                         java.security.Signature.getInstance(algorithm.getJvmName(), provider);
-
+                if (signature.getParameterSpec() != null) {
+                    instance.setParameter(signature.getParameterSpec());
+                }
                 instance.initSign(key);
                 instance.update(signingStringBytes);
                 return instance.sign();

--- a/src/main/java/org/tomitribe/auth/signatures/Verifier.java
+++ b/src/main/java/org/tomitribe/auth/signatures/Verifier.java
@@ -38,6 +38,12 @@ public class Verifier {
     private final Algorithm algorithm;
     private final Provider provider;
 
+    /**
+     * Constructs a verifier object with the specified key and signature object.
+     * 
+     * @param key The key used to verify the signature.
+     * @param signature The signature object.
+     */
     public Verifier(final Key key, final Signature signature) {
         this(key, signature, null);
     }
@@ -106,7 +112,9 @@ public class Verifier {
                 final java.security.Signature instance = provider == null ?
                         java.security.Signature.getInstance(algorithm.getJvmName()) :
                         java.security.Signature.getInstance(algorithm.getJvmName(), provider);
-
+                if (signature.getParameterSpec() != null) {
+                    instance.setParameter(signature.getParameterSpec());
+                }
                 instance.initVerify(key);
                 instance.update(signingStringBytes);
                 return instance.verify(Base64.decodeBase64(signature.getSignature().getBytes()));

--- a/src/test/java/org/tomitribe/auth/signatures/AlgorithmTest.java
+++ b/src/test/java/org/tomitribe/auth/signatures/AlgorithmTest.java
@@ -34,6 +34,7 @@ public class AlgorithmTest extends Assert {
         assertEquals("rsa-sha256", RSA_SHA256.getPortableName());
         assertEquals("rsa-sha384", RSA_SHA384.getPortableName());
         assertEquals("rsa-sha512", RSA_SHA512.getPortableName());
+        assertEquals("rsassa-pss", RSA_PSS.getPortableName());
         assertEquals("dsa-sha1", DSA_SHA1.getPortableName());
         assertEquals("dsa-sha224", DSA_SHA224.getPortableName());
         assertEquals("dsa-sha256", DSA_SHA256.getPortableName());
@@ -54,6 +55,7 @@ public class AlgorithmTest extends Assert {
         assertEquals("SHA256withRSA", RSA_SHA256.getJvmName());
         assertEquals("SHA384withRSA", RSA_SHA384.getJvmName());
         assertEquals("SHA512withRSA", RSA_SHA512.getJvmName());
+        assertEquals("RSASSA-PSS", RSA_PSS.getJvmName());
         assertEquals("SHA1withDSA", DSA_SHA1.getJvmName());
         assertEquals("SHA224withDSA", DSA_SHA224.getJvmName());
         assertEquals("SHA256withDSA", DSA_SHA256.getJvmName());

--- a/src/test/java/org/tomitribe/auth/signatures/EcTest.java
+++ b/src/test/java/org/tomitribe/auth/signatures/EcTest.java
@@ -24,6 +24,7 @@ import java.security.PrivateKey;
 import java.security.Provider;
 import java.security.PublicKey;
 import java.security.Security;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -143,7 +144,7 @@ public class EcTest extends Assert {
 
     private String generateSignature(final Algorithm algorithm, final String... sign) throws Exception {
 
-        final Signer signer = new Signer(privateKey, new Signature("some-key-1", algorithm, null, sign), SUN_EC_PROVIDER);
+        final Signer signer = new Signer(privateKey, new Signature("some-key-1", algorithm, null, null, Arrays.asList(sign)), SUN_EC_PROVIDER);
 
         final Signature signed = signer.sign(method, uri, headers);
 
@@ -152,7 +153,7 @@ public class EcTest extends Assert {
 
     private void verifySignature(final Algorithm algorithm, final String signature, final boolean expected, final String... sign) throws Exception {
 
-        final Verifier verifier = new Verifier(publicKey, new Signature("some-key-1", algorithm, signature, sign), SUN_EC_PROVIDER);
+        final Verifier verifier = new Verifier(publicKey, new Signature("some-key-1", algorithm, null, signature, Arrays.asList(sign)), SUN_EC_PROVIDER);
 
         assertEquals(expected, verifier.verify(method, uri, headers));
     }

--- a/src/test/java/org/tomitribe/auth/signatures/HmacTest.java
+++ b/src/test/java/org/tomitribe/auth/signatures/HmacTest.java
@@ -20,6 +20,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import javax.crypto.spec.SecretKeySpec;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -99,7 +100,7 @@ public class HmacTest extends Assert {
 
         final Signer signer = new Signer(
                 new SecretKeySpec(keyString.getBytes(), algorithm.getJvmName()),
-                new Signature("foo-key-1", algorithm, null, sign)
+                new Signature("foo-key-1", algorithm, null, null, Arrays.asList(sign))
         );
 
         final Signature signed = signer.sign(method, uri, headers);

--- a/src/test/java/org/tomitribe/auth/signatures/SignatureTest.java
+++ b/src/test/java/org/tomitribe/auth/signatures/SignatureTest.java
@@ -31,12 +31,12 @@ public class SignatureTest {
 
     @Test
     public void validSignature() {
-        new Signature("somekey", "hmac-sha256", "yT/NrPI9mKB5R7FTLRyFWvB+QLQOEAvbGmauC0tI+Jg=", "date", "accept");
+        new Signature("somekey", "hmac-sha256", null, "yT/NrPI9mKB5R7FTLRyFWvB+QLQOEAvbGmauC0tI+Jg=", Arrays.asList("date", "accept"));
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void nullKey() {
-        new Signature(null, "hmac-sha256", "yT/NrPI9mKB5R7FTLRyFWvB+QLQOEAvbGmauC0tI+Jg=", "date", "accept");
+        new Signature(null, "hmac-sha256", null, "yT/NrPI9mKB5R7FTLRyFWvB+QLQOEAvbGmauC0tI+Jg=", Arrays.asList("date", "accept"));
     }
 
     @Test
@@ -46,12 +46,12 @@ public class SignatureTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void nullAlgorithm() {
-        new Signature("somekey", (String) null, "yT/NrPI9mKB5R7FTLRyFWvB+QLQOEAvbGmauC0tI+Jg=", "date", "accept");
+        new Signature("somekey", (String) null, null, "yT/NrPI9mKB5R7FTLRyFWvB+QLQOEAvbGmauC0tI+Jg=", Arrays.asList("date", "accept"));
     }
 
     @Test
     public void nullHeaders() {
-        final Signature signature = new Signature("somekey", "hmac-sha256", "yT/NrPI9mKB5R7FTLRyFWvB+QLQOEAvbGmauC0tI+Jg=");
+        final Signature signature = new Signature("somekey", "hmac-sha256", null, "yT/NrPI9mKB5R7FTLRyFWvB+QLQOEAvbGmauC0tI+Jg=", Arrays.asList());
         assertEquals(1, signature.getHeaders().size()); // should contain at least the Date which is required
         assertEquals("date", signature.getHeaders().get(0).toLowerCase());
     }
@@ -59,7 +59,7 @@ public class SignatureTest {
 
     @Test
     public void roundTripTest() throws Exception {
-        final Signature expected = new Signature("somekey", "hmac-sha256", "yT/NrPI9mKB5R7FTLRyFWvB+QLQOEAvbGmauC0tI+Jg=", "date", "accept");
+        final Signature expected = new Signature("somekey", "hmac-sha256", null, "yT/NrPI9mKB5R7FTLRyFWvB+QLQOEAvbGmauC0tI+Jg=", Arrays.asList("date", "accept"));
         final Signature actual = Signature.fromString(expected.toString());
 
         assertSignature(expected, actual);
@@ -170,7 +170,7 @@ public class SignatureTest {
     @Test
     public void orderTolerance() throws Exception {
 
-        final Signature expected = new Signature("hmac-key-1", "hmac-sha256", "yT/NrPI9mKB5R7FTLRyFWvB+QLQOEAvbGmauC0tI+Jg=", "date", "accept");
+        final Signature expected = new Signature("hmac-key-1", "hmac-sha256", null, "yT/NrPI9mKB5R7FTLRyFWvB+QLQOEAvbGmauC0tI+Jg=", Arrays.asList("date", "accept"));
 
         final List<String> input = Arrays.asList(
                 "keyId=\"hmac-key-1\"",
@@ -195,7 +195,7 @@ public class SignatureTest {
     @Test
     public void caseNormalization() throws Exception {
 
-        final Signature signature = new Signature("hmac-key-1", "hMaC-ShA256", "yT/NrPI9mKB5R7FTLRyFWvB+QLQOEAvbGmauC0tI+Jg=", "dAte", "aCcEpt");
+        final Signature signature = new Signature("hmac-key-1", "hMaC-ShA256", null, "yT/NrPI9mKB5R7FTLRyFWvB+QLQOEAvbGmauC0tI+Jg=", Arrays.asList("dAte", "aCcEpt"));
 
         assertEquals("hmac-key-1", signature.getKeyId());
         assertEquals("hmac-sha256", signature.getAlgorithm().toString());
@@ -214,7 +214,7 @@ public class SignatureTest {
     @Test
     public void ambiguousParameters() throws Exception {
 
-        final Signature expected = new Signature("hmac-key-3", "dsa-sha1", "DPIsA/PWeYjySmfjw2P2SLJXZj1szDOei/Hh8nTcaPo=", "date");
+        final Signature expected = new Signature("hmac-key-3", "dsa-sha1", null, "DPIsA/PWeYjySmfjw2P2SLJXZj1szDOei/Hh8nTcaPo=", Arrays.asList("date"));
 
         final List<String> input = Arrays.asList(
                 "keyId=\"hmac-key-1\"",
@@ -236,7 +236,7 @@ public class SignatureTest {
     @Test
     public void parameterCaseTolerance() throws Exception {
 
-        final Signature expected = new Signature("hmac-key-3", "rsa-sha256", "DPIsA/PWeYjySmfjw2P2SLJXZj1szDOei/Hh8nTcaPo=", "date");
+        final Signature expected = new Signature("hmac-key-3", "rsa-sha256", null, "DPIsA/PWeYjySmfjw2P2SLJXZj1szDOei/Hh8nTcaPo=", Arrays.asList("date"));
 
         final List<String> input = Arrays.asList(
                 "keyId=\"hmac-key-1\"",
@@ -258,7 +258,7 @@ public class SignatureTest {
     @Test
     public void unknownParameters() throws Exception {
 
-        final Signature expected = new Signature("hmac-key-3", "rsa-sha256", "PIft5ByT/Nr5RWvB+QLQRyFAvbGmauCOE7FTL0tI+Jg=", "date");
+        final Signature expected = new Signature("hmac-key-3", "rsa-sha256", null, "PIft5ByT/Nr5RWvB+QLQRyFAvbGmauCOE7FTL0tI+Jg=", Arrays.asList("date"));
 
         final List<String> input = Arrays.asList(
                 "scopeId=\"hmac-key-1\"",
@@ -286,13 +286,13 @@ public class SignatureTest {
                 "signature=\"yT/NrPI9mKB5R7FTLRyFWvB+QLQOEAvbGmauC0tI+Jg=\"" +
                 " , ";
 
-        parseAndAssert(authorization, new Signature("hmac-key-1", "hmac-sha256", "yT/NrPI9mKB5R7FTLRyFWvB+QLQOEAvbGmauC0tI+Jg=", "date", "accept"));
+        parseAndAssert(authorization, new Signature("hmac-key-1", "hmac-sha256", null, "yT/NrPI9mKB5R7FTLRyFWvB+QLQOEAvbGmauC0tI+Jg=", Arrays.asList("date", "accept")));
     }
 
     @Test
     public void testToString() throws Exception {
 
-        final Signature signature = new Signature("hmac-key-1", "hmac-sha256", "Base64(HMAC-SHA256(signing string))", "(request-target)", "host", "date", "digest", "content-length");
+        final Signature signature = new Signature("hmac-key-1", "hmac-sha256", null, "Base64(HMAC-SHA256(signing string))", Arrays.asList("(request-target)", "host", "date", "digest", "content-length"));
 
         String authorization = "Signature keyId=\"hmac-key-1\"," +
                 "algorithm=\"hmac-sha256\"," +


### PR DESCRIPTION
To add support for the RSASSA-PSS algorithm, the client needs to be able to pass the cryptographic parameters, e.g. `PSSParameterSpec`. This is passed as one more `AlgorithmParameterSpec` argument in the Signature constructor. This could be used to specify parameters for other signature algorithms that also require parameters.

There is a dependency on #31 to specify the JVM version.