### PR TITLE
Add support for 'hs2019' algorithm

### DIFF
--- a/src/main/java/org/tomitribe/auth/signatures/Algorithm.java
+++ b/src/main/java/org/tomitribe/auth/signatures/Algorithm.java
@@ -20,6 +20,9 @@ import javax.crypto.Mac;
 import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * The cryptographic algorithms for the HTTP signature.
+ */
 public enum Algorithm {
 
     // hmac

--- a/src/main/java/org/tomitribe/auth/signatures/Signer.java
+++ b/src/main/java/org/tomitribe/auth/signatures/Signer.java
@@ -94,7 +94,9 @@ public class Signer {
 
         final String signedAndEncodedString = new String(encoded, "UTF-8");
 
-        return new Signature(signature.getKeyId(), signature.getAlgorithm(), signature.getParameterSpec(), signedAndEncodedString, signature.getHeaders());
+        return new Signature(signature.getKeyId(), signature.getSigningAlgorithm(),
+                             signature.getAlgorithm(), signature.getParameterSpec(),
+                             signedAndEncodedString, signature.getHeaders());
     }
 
     public String createSigningString(final String method, final String uri, final Map<String, String> headers) throws IOException {

--- a/src/main/java/org/tomitribe/auth/signatures/SigningAlgorithm.java
+++ b/src/main/java/org/tomitribe/auth/signatures/SigningAlgorithm.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.tomitribe.auth.signatures;
+
+import java.util.Map;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Set;
+import java.util.HashSet;
+import java.util.Arrays;
+
+/**
+ * The algorithm parameter contains the name of the signature's Algorithm,
+ * as registered in the HTTP Signature Algorithms Registry defined by this document.
+ * 
+ * The signature verification is based on the signature's algorithm from the keyId
+ * parameter rather than from this algorithm.
+ * If algorithm is provided and differs from or is incompatible with the algorithm
+ * or key material identified by keyId (for example, algorithm has a value of
+ * rsa-sha256 but keyId identifies an EdDSA key), then a verification exception is
+ * raised.
+ * 
+ * The default value for this parameter should be "hs2019".
+ * 
+ * @see https://www.ietf.org/id/draft-ietf-httpbis-message-signatures-00.html
+ */
+public enum SigningAlgorithm {
+
+    /**
+     * The actual cryptographic algorithm is derived from metadata associated
+     * with keyId.
+     * 
+     * Recommend support for:
+     *   RSASSA-PSS [RFC8017] using SHA-512 [RFC6234]
+     *   HMAC [RFC2104] using SHA-512 [RFC6234]
+     *   ECDSA using curve P-256 [DSS] and SHA-512 [RFC6234]
+     *   Ed25519ph, Ed25519ctx, and Ed25519 [RFC8032]
+     */
+    HS2019("hs2019", null),
+
+    // Deprecated, SHA-1 is not secure.
+    // Use hs2019.
+    RSA_SHA1("rsa-sha1", new HashSet<Algorithm>(Arrays.asList(Algorithm.RSA_SHA1))),
+    // Deprecated, specifying signature algorithm enables attack vector.
+    // Use hs2019.
+    RSA_SHA256("rsa-sha256", new HashSet<Algorithm>(Arrays.asList(Algorithm.RSA_SHA256))),
+    // Deprecated, specifying signature algorithm enables attack vector.
+    // Use hs2019.
+    ECDSA_SHA256("ecdsa-sha256", new HashSet<Algorithm>(Arrays.asList(Algorithm.ECDSA_SHA256))),
+    // Deprecated, specifying signature algorithm enables attack vector.
+    // Use hs2019.
+    HMAC_SHA256("hmac-sha256", new HashSet<Algorithm>(Arrays.asList(Algorithm.HMAC_SHA256))),
+    ;
+
+    private static final Map<String, SigningAlgorithm> aliases = new HashMap<String, SigningAlgorithm>();
+
+    static {
+        for (final SigningAlgorithm algorithmName : SigningAlgorithm.values()) {
+            aliases.put(algorithmName.getAlgorithmName(), algorithmName);
+        }
+    }
+
+    /**
+     * An identifier for the HTTP Signature Algorithm.
+     * The name MUST be an ASCII string consisting only of lower-case characters ("a" - "z"),
+     * digits ("0" - "9"), and hyphens ("-"), and SHOULD NOT exceed 20 characters in length.
+     * The identifier MUST be unique within the context of the registry.
+     */
+    private final String algorithmName;
+    private final Set<Algorithm> supportedAlgorithms;
+
+    SigningAlgorithm(final String algorithmName, final Set<Algorithm> supportedAlgorithms) {
+        this.algorithmName = algorithmName;
+        if (supportedAlgorithms != null) {
+            this.supportedAlgorithms = Collections.unmodifiableSet(supportedAlgorithms);
+        } else {
+            this.supportedAlgorithms = null;
+        }
+    }
+
+    public String getAlgorithmName() {
+        return algorithmName;
+    }
+
+    public Set<Algorithm> getSupportedAlgorithms() {
+        return this.supportedAlgorithms;
+    }
+
+    /**
+     * Returns the SigningAlgorithm with the specified name.
+     * 
+     * @param name the name of the signing algorithm.
+     * @return the SigningAlgorithm
+     */
+    public static SigningAlgorithm get(final String name) {
+        final SigningAlgorithm algorithmName = aliases.get(name);
+        if (algorithmName != null) return algorithmName;
+        throw new UnsupportedAlgorithmException(name);
+    }
+
+    @Override
+    public String toString() {
+        return getAlgorithmName();
+    }
+}

--- a/src/test/java/org/tomitribe/auth/signatures/EcTest.java
+++ b/src/test/java/org/tomitribe/auth/signatures/EcTest.java
@@ -144,7 +144,8 @@ public class EcTest extends Assert {
 
     private String generateSignature(final Algorithm algorithm, final String... sign) throws Exception {
 
-        final Signer signer = new Signer(privateKey, new Signature("some-key-1", algorithm, null, null, Arrays.asList(sign)), SUN_EC_PROVIDER);
+        final Signer signer = new Signer(privateKey,
+                new Signature("some-key-1", SigningAlgorithm.HS2019, algorithm, null, null, Arrays.asList(sign)), SUN_EC_PROVIDER);
 
         final Signature signed = signer.sign(method, uri, headers);
 
@@ -153,7 +154,8 @@ public class EcTest extends Assert {
 
     private void verifySignature(final Algorithm algorithm, final String signature, final boolean expected, final String... sign) throws Exception {
 
-        final Verifier verifier = new Verifier(publicKey, new Signature("some-key-1", algorithm, null, signature, Arrays.asList(sign)), SUN_EC_PROVIDER);
+        final Verifier verifier = new Verifier(publicKey,
+                new Signature("some-key-1", SigningAlgorithm.HS2019, algorithm, null, signature, Arrays.asList(sign)), SUN_EC_PROVIDER);
 
         assertEquals(expected, verifier.verify(method, uri, headers));
     }

--- a/src/test/java/org/tomitribe/auth/signatures/HmacTest.java
+++ b/src/test/java/org/tomitribe/auth/signatures/HmacTest.java
@@ -100,7 +100,7 @@ public class HmacTest extends Assert {
 
         final Signer signer = new Signer(
                 new SecretKeySpec(keyString.getBytes(), algorithm.getJvmName()),
-                new Signature("foo-key-1", algorithm, null, null, Arrays.asList(sign))
+                new Signature("foo-key-1", SigningAlgorithm.HS2019, algorithm, null, null, Arrays.asList(sign))
         );
 
         final Signature signed = signer.sign(method, uri, headers);

--- a/src/test/java/org/tomitribe/auth/signatures/RsaTest.java
+++ b/src/test/java/org/tomitribe/auth/signatures/RsaTest.java
@@ -153,7 +153,8 @@ public class RsaTest extends Assert {
     public void rsaSsaPss() throws Exception {
         final Algorithm algorithm = Algorithm.RSA_PSS;
         final AlgorithmParameterSpec spec = new PSSParameterSpec("SHA-256", "MGF1", MGF1ParameterSpec.SHA256, 32, 1);
-        final Signer signer = new Signer(privateKey, new Signature("some-key-1", algorithm, spec, null, Arrays.asList("date")));
+        final Signer signer = new Signer(privateKey,
+                new Signature("some-key-1", SigningAlgorithm.HS2019, algorithm, spec, null, Arrays.asList("date")));
 
         final Signature signature = signer.sign(method, uri, headers);
         // The RSASSA-PSS signature is non-deterministic, the value of the signature will be different
@@ -165,7 +166,8 @@ public class RsaTest extends Assert {
 
     private void assertSignature(final Algorithm algorithm, final String expected, final String... sign) throws Exception {
 
-        final Signer signer = new Signer(privateKey, new Signature("some-key-1", algorithm, null, null, Arrays.asList(sign)));
+        final Signer signer = new Signer(privateKey,
+                new Signature("some-key-1", SigningAlgorithm.HS2019, algorithm, null, null, Arrays.asList(sign)));
 
         final Signature signed = signer.sign(method, uri, headers);
 

--- a/src/test/java/org/tomitribe/auth/signatures/SignatureTest.java
+++ b/src/test/java/org/tomitribe/auth/signatures/SignatureTest.java
@@ -88,6 +88,28 @@ public class SignatureTest {
                 "content-length", join("\n", signature.getHeaders()));
     }
 
+    /**
+     * Same as testFromString, but the algorithm is set to 'hs2019',
+     * @throws Exception
+     */
+    @Test
+    public void testFromStringHmacSha256() throws Exception {
+        String authorization = "Signature keyId=\"hmac-key-1\",algorithm=\"hs2019\",\n" +
+                "   headers=\"(request-target) host date digest content-length\",\n" +
+                "   signature=\"yT/NrPI9mKB5R7FTLRyFWvB+QLQOEAvbGmauC0tI+Jg=\"";
+
+        final Signature signature = Signature.fromString(authorization, Algorithm.HMAC_SHA256);
+
+        assertEquals("hmac-key-1", signature.getKeyId());
+        assertEquals("hmac-sha256", signature.getAlgorithm().toString());
+        assertEquals("yT/NrPI9mKB5R7FTLRyFWvB+QLQOEAvbGmauC0tI+Jg=", signature.getSignature());
+        assertEquals("(request-target)\n" +
+                "host\n" +
+                "date\n" +
+                "digest\n" +
+                "content-length", join("\n", signature.getHeaders()));
+    }
+
     @Test
     public void testFromStringWithLdapDNKeyId() throws Exception {
         String authorization = "Signature keyId=\"UID=jsmith,DC=example,DC=net\",algorithm=\"hmac-sha256\",\n" +

--- a/src/test/java/org/tomitribe/auth/signatures/SignatureTest.java
+++ b/src/test/java/org/tomitribe/auth/signatures/SignatureTest.java
@@ -31,27 +31,32 @@ public class SignatureTest {
 
     @Test
     public void validSignature() {
-        new Signature("somekey", "hmac-sha256", null, "yT/NrPI9mKB5R7FTLRyFWvB+QLQOEAvbGmauC0tI+Jg=", Arrays.asList("date", "accept"));
+        new Signature("somekey", SigningAlgorithm.HS2019.getAlgorithmName(), "hmac-sha256", null, "yT/NrPI9mKB5R7FTLRyFWvB+QLQOEAvbGmauC0tI+Jg=", Arrays.asList("date", "accept"));
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void nullKey() {
-        new Signature(null, "hmac-sha256", null, "yT/NrPI9mKB5R7FTLRyFWvB+QLQOEAvbGmauC0tI+Jg=", Arrays.asList("date", "accept"));
+        new Signature(null, SigningAlgorithm.HS2019.getAlgorithmName(), "hmac-sha256", null, "yT/NrPI9mKB5R7FTLRyFWvB+QLQOEAvbGmauC0tI+Jg=", Arrays.asList("date", "accept"));
     }
 
     @Test
     public void nullSignature() {
-        new Signature("somekey", "hmac-sha256", null, "date", "accept");
+        new Signature("somekey", SigningAlgorithm.HS2019.getAlgorithmName(), "hmac-sha256", null, null, Arrays.asList("date", "accept"));
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void nullAlgorithm() {
-        new Signature("somekey", (String) null, null, "yT/NrPI9mKB5R7FTLRyFWvB+QLQOEAvbGmauC0tI+Jg=", Arrays.asList("date", "accept"));
+        new Signature("somekey", SigningAlgorithm.HS2019.getAlgorithmName(), (String) null, null, "yT/NrPI9mKB5R7FTLRyFWvB+QLQOEAvbGmauC0tI+Jg=", Arrays.asList("date", "accept"));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void nullSigningAlgorithm() {
+        new Signature("somekey", null, "hmac-sha256", null, "yT/NrPI9mKB5R7FTLRyFWvB+QLQOEAvbGmauC0tI+Jg=", Arrays.asList("date", "accept"));
     }
 
     @Test
     public void nullHeaders() {
-        final Signature signature = new Signature("somekey", "hmac-sha256", null, "yT/NrPI9mKB5R7FTLRyFWvB+QLQOEAvbGmauC0tI+Jg=", Arrays.asList());
+        final Signature signature = new Signature("somekey", SigningAlgorithm.HS2019.getAlgorithmName(), "hmac-sha256", null, "yT/NrPI9mKB5R7FTLRyFWvB+QLQOEAvbGmauC0tI+Jg=", Arrays.asList());
         assertEquals(1, signature.getHeaders().size()); // should contain at least the Date which is required
         assertEquals("date", signature.getHeaders().get(0).toLowerCase());
     }
@@ -59,8 +64,8 @@ public class SignatureTest {
 
     @Test
     public void roundTripTest() throws Exception {
-        final Signature expected = new Signature("somekey", "hmac-sha256", null, "yT/NrPI9mKB5R7FTLRyFWvB+QLQOEAvbGmauC0tI+Jg=", Arrays.asList("date", "accept"));
-        final Signature actual = Signature.fromString(expected.toString());
+        final Signature expected = new Signature("somekey", SigningAlgorithm.HS2019.getAlgorithmName(), "hmac-sha256", null, "yT/NrPI9mKB5R7FTLRyFWvB+QLQOEAvbGmauC0tI+Jg=", Arrays.asList("date", "accept"));
+        final Signature actual = Signature.fromString(expected.toString(), null);
 
         assertSignature(expected, actual);
     }
@@ -71,7 +76,7 @@ public class SignatureTest {
                 "   headers=\"(request-target) host date digest content-length\",\n" +
                 "   signature=\"yT/NrPI9mKB5R7FTLRyFWvB+QLQOEAvbGmauC0tI+Jg=\"";
 
-        final Signature signature = Signature.fromString(authorization);
+        final Signature signature = Signature.fromString(authorization, null);
 
         assertEquals("hmac-key-1", signature.getKeyId());
         assertEquals("hmac-sha256", signature.getAlgorithm().toString());
@@ -89,7 +94,7 @@ public class SignatureTest {
                 "   headers=\"(request-target) host date digest content-length\",\n" +
                 "   signature=\"yT/NrPI9mKB5R7FTLRyFWvB+QLQOEAvbGmauC0tI+Jg=\"";
 
-        final Signature signature = Signature.fromString(authorization);
+        final Signature signature = Signature.fromString(authorization, null);
 
         assertEquals("UID=jsmith,DC=example,DC=net", signature.getKeyId());
     }
@@ -103,7 +108,7 @@ public class SignatureTest {
         String authorization = "Signature keyId=\"hmac-key-1\",algorithm=\"hmac-sha256\",\n" +
                 "   signature=\"Base64(HMAC-SHA256(signing string))\"";
 
-        final Signature signature = Signature.fromString(authorization);
+        final Signature signature = Signature.fromString(authorization, null);
 
         assertEquals("hmac-key-1", signature.getKeyId());
         assertEquals("hmac-sha256", signature.getAlgorithm().toString());
@@ -120,7 +125,7 @@ public class SignatureTest {
                 "headers=\"one two three four five six\"" +
                 ",signature=\"Base64(HMAC-SHA256(signing string))\"";
 
-        final Signature signature = Signature.fromString(authorization);
+        final Signature signature = Signature.fromString(authorization, null);
 
         assertEquals("hmac-key-1", signature.getKeyId());
         assertEquals("hmac-sha256", signature.getAlgorithm().toString());
@@ -138,7 +143,7 @@ public class SignatureTest {
         String authorization = "keyId=\"hmac-key-1\",algorithm=\"hmac-sha256\",\n" +
                 "   signature=\"Base64(HMAC-SHA256(signing string))\"";
 
-        final Signature signature = Signature.fromString(authorization);
+        final Signature signature = Signature.fromString(authorization, null);
 
         assertEquals("hmac-key-1", signature.getKeyId());
         assertEquals("hmac-sha256", signature.getAlgorithm().toString());
@@ -155,8 +160,13 @@ public class SignatureTest {
         String authorization = "  \nkeyId=\"hmac-key-1\",algorithm=\"hmac-sha256\",\n" +
                 "   signature=\"Base64(HMAC-SHA256(signing string))\"  \n";
 
-        final Signature signature = Signature.fromString(authorization);
+        Signature signature = Signature.fromString(authorization, null);
+        assertEquals("hmac-key-1", signature.getKeyId());
+        assertEquals("hmac-sha256", signature.getAlgorithm().toString());
+        assertEquals("Base64(HMAC-SHA256(signing string))", signature.getSignature());
+        assertEquals("date", join("\n", signature.getHeaders()));
 
+        signature = Signature.fromString(authorization, Algorithm.HMAC_SHA256);
         assertEquals("hmac-key-1", signature.getKeyId());
         assertEquals("hmac-sha256", signature.getAlgorithm().toString());
         assertEquals("Base64(HMAC-SHA256(signing string))", signature.getSignature());
@@ -170,7 +180,7 @@ public class SignatureTest {
     @Test
     public void orderTolerance() throws Exception {
 
-        final Signature expected = new Signature("hmac-key-1", "hmac-sha256", null, "yT/NrPI9mKB5R7FTLRyFWvB+QLQOEAvbGmauC0tI+Jg=", Arrays.asList("date", "accept"));
+        final Signature expected = new Signature("hmac-key-1", SigningAlgorithm.HS2019.getAlgorithmName(), "hmac-sha256", null, "yT/NrPI9mKB5R7FTLRyFWvB+QLQOEAvbGmauC0tI+Jg=", Arrays.asList("date", "accept"));
 
         final List<String> input = Arrays.asList(
                 "keyId=\"hmac-key-1\"",
@@ -195,7 +205,7 @@ public class SignatureTest {
     @Test
     public void caseNormalization() throws Exception {
 
-        final Signature signature = new Signature("hmac-key-1", "hMaC-ShA256", null, "yT/NrPI9mKB5R7FTLRyFWvB+QLQOEAvbGmauC0tI+Jg=", Arrays.asList("dAte", "aCcEpt"));
+        final Signature signature = new Signature("hmac-key-1", SigningAlgorithm.HS2019.getAlgorithmName(), "hMaC-ShA256", null, "yT/NrPI9mKB5R7FTLRyFWvB+QLQOEAvbGmauC0tI+Jg=", Arrays.asList("dAte", "aCcEpt"));
 
         assertEquals("hmac-key-1", signature.getKeyId());
         assertEquals("hmac-sha256", signature.getAlgorithm().toString());
@@ -214,7 +224,7 @@ public class SignatureTest {
     @Test
     public void ambiguousParameters() throws Exception {
 
-        final Signature expected = new Signature("hmac-key-3", "dsa-sha1", null, "DPIsA/PWeYjySmfjw2P2SLJXZj1szDOei/Hh8nTcaPo=", Arrays.asList("date"));
+        final Signature expected = new Signature("hmac-key-3", SigningAlgorithm.HS2019.getAlgorithmName(), "dsa-sha1", null, "DPIsA/PWeYjySmfjw2P2SLJXZj1szDOei/Hh8nTcaPo=", Arrays.asList("date"));
 
         final List<String> input = Arrays.asList(
                 "keyId=\"hmac-key-1\"",
@@ -236,7 +246,7 @@ public class SignatureTest {
     @Test
     public void parameterCaseTolerance() throws Exception {
 
-        final Signature expected = new Signature("hmac-key-3", "rsa-sha256", null, "DPIsA/PWeYjySmfjw2P2SLJXZj1szDOei/Hh8nTcaPo=", Arrays.asList("date"));
+        final Signature expected = new Signature("hmac-key-3", SigningAlgorithm.HS2019.getAlgorithmName(), "rsa-sha256", null, "DPIsA/PWeYjySmfjw2P2SLJXZj1szDOei/Hh8nTcaPo=", Arrays.asList("date"));
 
         final List<String> input = Arrays.asList(
                 "keyId=\"hmac-key-1\"",
@@ -258,7 +268,7 @@ public class SignatureTest {
     @Test
     public void unknownParameters() throws Exception {
 
-        final Signature expected = new Signature("hmac-key-3", "rsa-sha256", null, "PIft5ByT/Nr5RWvB+QLQRyFAvbGmauCOE7FTL0tI+Jg=", Arrays.asList("date"));
+        final Signature expected = new Signature("hmac-key-3", SigningAlgorithm.HS2019.getAlgorithmName(), "rsa-sha256", null, "PIft5ByT/Nr5RWvB+QLQRyFAvbGmauCOE7FTL0tI+Jg=", Arrays.asList("date"));
 
         final List<String> input = Arrays.asList(
                 "scopeId=\"hmac-key-1\"",
@@ -286,13 +296,13 @@ public class SignatureTest {
                 "signature=\"yT/NrPI9mKB5R7FTLRyFWvB+QLQOEAvbGmauC0tI+Jg=\"" +
                 " , ";
 
-        parseAndAssert(authorization, new Signature("hmac-key-1", "hmac-sha256", null, "yT/NrPI9mKB5R7FTLRyFWvB+QLQOEAvbGmauC0tI+Jg=", Arrays.asList("date", "accept")));
+        parseAndAssert(authorization, new Signature("hmac-key-1", SigningAlgorithm.HS2019.getAlgorithmName(), "hmac-sha256", null, "yT/NrPI9mKB5R7FTLRyFWvB+QLQOEAvbGmauC0tI+Jg=", Arrays.asList("date", "accept")));
     }
 
     @Test
     public void testToString() throws Exception {
 
-        final Signature signature = new Signature("hmac-key-1", "hmac-sha256", null, "Base64(HMAC-SHA256(signing string))", Arrays.asList("(request-target)", "host", "date", "digest", "content-length"));
+        final Signature signature = new Signature("hmac-key-1", SigningAlgorithm.HS2019.getAlgorithmName(), "hmac-sha256", null, "Base64(HMAC-SHA256(signing string))", Arrays.asList("(request-target)", "host", "date", "digest", "content-length"));
 
         String authorization = "Signature keyId=\"hmac-key-1\"," +
                 "algorithm=\"hmac-sha256\"," +
@@ -325,7 +335,7 @@ public class SignatureTest {
 
             try {
 
-                Signature.fromString(authorization.toString());
+                Signature.fromString(authorization.toString(), null);
 
             } catch (AuthenticationException e) {
                 // pass
@@ -343,7 +353,7 @@ public class SignatureTest {
                 "headers=\"(request-target) host date digest content-length\"," +
                 "signature=\"yT/NrPI9mKB5R7FTLRyFWvB+QLQOEAvbGmauC0tI+Jg=\"";
 
-        Signature.fromString(authorization);
+        Signature.fromString(authorization, null);
     }
 
     @Test(expected = MissingAlgorithmException.class)
@@ -354,7 +364,7 @@ public class SignatureTest {
                 "headers=\"(request-target) host date digest content-length\"," +
                 "signature=\"yT/NrPI9mKB5R7FTLRyFWvB+QLQOEAvbGmauC0tI+Jg=\"";
 
-        Signature.fromString(authorization);
+        Signature.fromString(authorization, null);
     }
 
 
@@ -366,12 +376,12 @@ public class SignatureTest {
                 "headers=\"(request-target) host date digest content-length\"";
 //                "signature=\"yT/NrPI9mKB5R7FTLRyFWvB+QLQOEAvbGmauC0tI+Jg=\"";
 
-        Signature.fromString(authorization);
+        Signature.fromString(authorization, null);
     }
 
 
     private static void parseAndAssert(final String authorization, final Signature expected) {
-        final Signature actual = Signature.fromString(authorization);
+        final Signature actual = Signature.fromString(authorization, null);
         assertSignature(expected, actual);
     }
 

--- a/src/test/java/org/tomitribe/auth/signatures/SignerTest.java
+++ b/src/test/java/org/tomitribe/auth/signatures/SignerTest.java
@@ -24,19 +24,20 @@ import java.security.Key;
 import java.security.Provider;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Arrays;
 
 public class SignerTest extends Assert {
 
     @Test
     public void validSigner() {
-        final Signature signature = new Signature("hmac-key-1", "hmac-sha256", null, "content-length", "host", "date", "(request-target)");
+        final Signature signature = new Signature("hmac-key-1", SigningAlgorithm.HS2019.getAlgorithmName(), "hmac-sha256", null, null, Arrays.asList("content-length", "host", "date", "(request-target)"));
         final Key key = new SecretKeySpec("don't tell".getBytes(), "HmacSHA256");
         new Signer(key, signature);
     }
 
     @Test(expected = NullPointerException.class)
     public void nullKey() {
-        final Signature signature = new Signature("hmac-key-1", "hmac-sha256", null, "content-length", "host", "date", "(request-target)");
+        final Signature signature = new Signature("hmac-key-1", SigningAlgorithm.HS2019.getAlgorithmName(), "hmac-sha256", null, null, Arrays.asList("content-length", "host", "date", "(request-target)"));
         new Signer(null, signature);
     }
 
@@ -48,7 +49,21 @@ public class SignerTest extends Assert {
 
     @Test(expected = UnsupportedAlgorithmException.class)
     public void unsupportedAlgorithm() {
-        final Signature signature = new Signature("hmac-key-1", "should fail because of this", null, "content-length", "host", "date", "(request-target)");
+        final Signature signature = new Signature("hmac-key-1", SigningAlgorithm.HS2019.getAlgorithmName(), "should fail because of this", null, null, Arrays.asList("content-length", "host", "date", "(request-target)"));
+        final Key key = new SecretKeySpec("don't tell".getBytes(), "HmacSHA256");
+        new Signer(key, signature);
+    }
+
+    @Test(expected = UnsupportedAlgorithmException.class)
+    public void unsupportedSigningAlgorithm() {
+        final Signature signature = new Signature("hmac-key-1", "unsupported signing algorithm", "hmac-sha256", null, Arrays.asList("content-length", "host", "date", "(request-target)"));
+        final Key key = new SecretKeySpec("don't tell".getBytes(), "HmacSHA256");
+        new Signer(key, signature);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void conflictingSigningAlgorithm() {
+        final Signature signature = new Signature("hmac-key-1", SigningAlgorithm.RSA_SHA256.getAlgorithmName(), "hmac-sha256", null, Arrays.asList("content-length", "host", "date", "(request-target)"));
         final Key key = new SecretKeySpec("don't tell".getBytes(), "HmacSHA256");
         new Signer(key, signature);
     }
@@ -59,7 +74,7 @@ public class SignerTest extends Assert {
             clear();
         }};
 
-        final Signature signature = new Signature("hmac-key-1", "hmac-sha256", null, "content-length", "host", "date", "(request-target)");
+        final Signature signature = new Signature("hmac-key-1", SigningAlgorithm.HS2019.getAlgorithmName(), "hmac-sha256", null, null, Arrays.asList("content-length", "host", "date", "(request-target)"));
         final Key key = new SecretKeySpec("don't tell".getBytes(), "HmacSHA256");
         new Signer(key, signature, p);
     }
@@ -75,7 +90,7 @@ public class SignerTest extends Assert {
     @Test
     public void testSign() throws Exception {
 
-        final Signature signature = new Signature("hmac-key-1", "hmac-sha256", null, "content-length", "host", "date", "(request-target)");
+        final Signature signature = new Signature("hmac-key-1", SigningAlgorithm.HS2019.getAlgorithmName(), "hmac-sha256", null, null, Arrays.asList("content-length", "host", "date", "(request-target)"));
 
         final Key key = new SecretKeySpec("don't tell".getBytes(), "HmacSHA256");
         final Signer signer = new Signer(key, signature);
@@ -139,7 +154,8 @@ public class SignerTest extends Assert {
 
     @Test
     public void defaultHeaderList() throws Exception {
-        final Signature signature = new Signature("hmac-key-1", "hmac-sha256", null);
+        final Signature signature = new Signature("hmac-key-1", SigningAlgorithm.HS2019.getAlgorithmName(), "hmac-sha256",
+                                                    null, null);
 
         final Key key = new SecretKeySpec("don't tell".getBytes(), "HmacSHA256");
         final Signer signer = new Signer(key, signature);
@@ -175,7 +191,7 @@ public class SignerTest extends Assert {
 
     @Test(expected = MissingRequiredHeaderException.class)
     public void missingDefaultHeader() throws Exception {
-        final Signature signature = new Signature("hmac-key-1", "hmac-sha256", null);
+        final Signature signature = new Signature("hmac-key-1", SigningAlgorithm.HS2019.getAlgorithmName(), "hmac-sha256", null, null);
 
         final Key key = new SecretKeySpec("don't tell".getBytes(), "HmacSHA256");
         final Signer signer = new Signer(key, signature);
@@ -186,7 +202,7 @@ public class SignerTest extends Assert {
 
     @Test(expected = MissingRequiredHeaderException.class)
     public void missingExplicitHeader() throws Exception {
-        final Signature signature = new Signature("hmac-key-1", "hmac-sha256", null, "date", "accept");
+        final Signature signature = new Signature("hmac-key-1", SigningAlgorithm.HS2019.getAlgorithmName(), "hmac-sha256", null, null, Arrays.asList("date", "accept"));
 
         final Key key = new SecretKeySpec("don't tell".getBytes(), "HmacSHA256");
         final Signer signer = new Signer(key, signature);
@@ -198,7 +214,7 @@ public class SignerTest extends Assert {
 
     @Test
     public void testSign1() throws Exception {
-        final Signature signature = new Signature("hmac-key-1", "hmac-sha256", null, "content-length", "host", "date", "(request-target)");
+        final Signature signature = new Signature("hmac-key-1", SigningAlgorithm.HS2019.getAlgorithmName(), "hmac-sha256", null, null, Arrays.asList("content-length", "host", "date", "(request-target)"));
 
         final Key key = new SecretKeySpec("don't tell".getBytes(), "HmacSHA256");
         final Signer signer = new Signer(key, signature);
@@ -243,7 +259,7 @@ public class SignerTest extends Assert {
             headers.put("Accept", "*/*");
             headers.put("Content-Length", "18");
 
-            final Signature signature = new Signature("hmac-key-1", "hmac-sha256", null, "(request-target)", "host", "date", "digest", "content-length");
+            final Signature signature = new Signature("hmac-key-1", SigningAlgorithm.HS2019.getAlgorithmName(), "hmac-sha256", null, null, Arrays.asList("(request-target)", "host", "date", "digest", "content-length"));
             final Key key = new SecretKeySpec("don't tell".getBytes(), "HmacSHA256");
             final Signer signer = new Signer(key, signature);
 
@@ -266,7 +282,7 @@ public class SignerTest extends Assert {
             headers.put("Accept", "*/*");
             headers.put("Content-Length", "18");
 
-            final Signature signature = new Signature("hmac-key-1", "hmac-sha256", null, "content-length", "host", "date", "(request-target)");
+            final Signature signature = new Signature("hmac-key-1", SigningAlgorithm.HS2019.getAlgorithmName(), "hmac-sha256", null, null, Arrays.asList("content-length", "host", "date", "(request-target)"));
             final Key key = new SecretKeySpec("don't tell".getBytes(), "HmacSHA256");
             final Signer signer = new Signer(key, signature);
 


### PR DESCRIPTION
In the most recent [IETF draft](https://datatracker.ietf.org/doc/draft-ietf-httpbis-message-signatures/), the `algorithm` field should be set to HS2019.
This PR adds support for HS2019

There is a dependency on #31 on #32.