### PR TITLE
Issue #41 Fix value of 'algorithm' field when signing algorithm is set to 'hs2019'

### DIFF
--- a/src/main/java/org/tomitribe/auth/signatures/Signature.java
+++ b/src/main/java/org/tomitribe/auth/signatures/Signature.java
@@ -300,9 +300,19 @@ public class Signature {
 
     @Override
     public String toString() {
+        Object alg;
+        if (SigningAlgorithm.HS2019.equals(signingAlgorithm)) {
+            // When the signing algorithm is set to 'hs2019', the value of the algorithm
+            // field must be set to 'hs2019'. The specific crypto algorithm is not
+            // serialized in the 'Authorization' header, the server must derive the value
+            // from the keyId.
+            alg = signingAlgorithm;
+        } else {
+            alg = algorithm;
+        }
         return "Signature " +
                 "keyId=\"" + keyId + '\"' +
-                ",algorithm=\"" + algorithm + '\"' +
+                ",algorithm=\"" + alg + '\"' +
                 ",headers=\"" + Join.join(" ", headers) + '\"' +
                 ",signature=\"" + signature + '\"';
     }

--- a/src/test/java/org/tomitribe/auth/signatures/AlgorithmTest.java
+++ b/src/test/java/org/tomitribe/auth/signatures/AlgorithmTest.java
@@ -102,4 +102,12 @@ public class AlgorithmTest extends Assert {
     public void unsupportedAlgorithmException() throws Exception {
         Algorithm.get("HmacMD256");
     }
+
+    @Test
+    public void getSigningAlgorithm() throws Exception {
+        for (final SigningAlgorithm algorithm : SigningAlgorithm.values()) {
+            SigningAlgorithm s = SigningAlgorithm.get(algorithm.getAlgorithmName());
+            assertEquals(algorithm, s);
+        }
+    }    
 }

--- a/src/test/java/org/tomitribe/auth/signatures/SignatureTest.java
+++ b/src/test/java/org/tomitribe/auth/signatures/SignatureTest.java
@@ -56,7 +56,7 @@ public class SignatureTest {
 
     @Test
     public void nullHeaders() {
-        final Signature signature = new Signature("somekey", SigningAlgorithm.HS2019.getAlgorithmName(), "hmac-sha256", null, "yT/NrPI9mKB5R7FTLRyFWvB+QLQOEAvbGmauC0tI+Jg=", Arrays.asList());
+        final Signature signature = new Signature("somekey", SigningAlgorithm.HMAC_SHA256.getAlgorithmName(), "hmac-sha256", null, "yT/NrPI9mKB5R7FTLRyFWvB+QLQOEAvbGmauC0tI+Jg=", Arrays.asList());
         assertEquals(1, signature.getHeaders().size()); // should contain at least the Date which is required
         assertEquals("date", signature.getHeaders().get(0).toLowerCase());
     }
@@ -64,7 +64,7 @@ public class SignatureTest {
 
     @Test
     public void roundTripTest() throws Exception {
-        final Signature expected = new Signature("somekey", SigningAlgorithm.HS2019.getAlgorithmName(), "hmac-sha256", null, "yT/NrPI9mKB5R7FTLRyFWvB+QLQOEAvbGmauC0tI+Jg=", Arrays.asList("date", "accept"));
+        final Signature expected = new Signature("somekey", SigningAlgorithm.HMAC_SHA256.getAlgorithmName(), "hmac-sha256", null, "yT/NrPI9mKB5R7FTLRyFWvB+QLQOEAvbGmauC0tI+Jg=", Arrays.asList("date", "accept"));
         final Signature actual = Signature.fromString(expected.toString(), null);
 
         assertSignature(expected, actual);
@@ -202,7 +202,7 @@ public class SignatureTest {
     @Test
     public void orderTolerance() throws Exception {
 
-        final Signature expected = new Signature("hmac-key-1", SigningAlgorithm.HS2019.getAlgorithmName(), "hmac-sha256", null, "yT/NrPI9mKB5R7FTLRyFWvB+QLQOEAvbGmauC0tI+Jg=", Arrays.asList("date", "accept"));
+        final Signature expected = new Signature("hmac-key-1", SigningAlgorithm.HMAC_SHA256.getAlgorithmName(), "hmac-sha256", null, "yT/NrPI9mKB5R7FTLRyFWvB+QLQOEAvbGmauC0tI+Jg=", Arrays.asList("date", "accept"));
 
         final List<String> input = Arrays.asList(
                 "keyId=\"hmac-key-1\"",
@@ -227,7 +227,7 @@ public class SignatureTest {
     @Test
     public void caseNormalization() throws Exception {
 
-        final Signature signature = new Signature("hmac-key-1", SigningAlgorithm.HS2019.getAlgorithmName(), "hMaC-ShA256", null, "yT/NrPI9mKB5R7FTLRyFWvB+QLQOEAvbGmauC0tI+Jg=", Arrays.asList("dAte", "aCcEpt"));
+        final Signature signature = new Signature("hmac-key-1", SigningAlgorithm.HMAC_SHA256.getAlgorithmName(), "hMaC-ShA256", null, "yT/NrPI9mKB5R7FTLRyFWvB+QLQOEAvbGmauC0tI+Jg=", Arrays.asList("dAte", "aCcEpt"));
 
         assertEquals("hmac-key-1", signature.getKeyId());
         assertEquals("hmac-sha256", signature.getAlgorithm().toString());
@@ -324,7 +324,7 @@ public class SignatureTest {
     @Test
     public void testToString() throws Exception {
 
-        final Signature signature = new Signature("hmac-key-1", SigningAlgorithm.HS2019.getAlgorithmName(), "hmac-sha256", null, "Base64(HMAC-SHA256(signing string))", Arrays.asList("(request-target)", "host", "date", "digest", "content-length"));
+        final Signature signature = new Signature("hmac-key-1", SigningAlgorithm.HMAC_SHA256.getAlgorithmName(), "hmac-sha256", null, "Base64(HMAC-SHA256(signing string))", Arrays.asList("(request-target)", "host", "date", "digest", "content-length"));
 
         String authorization = "Signature keyId=\"hmac-key-1\"," +
                 "algorithm=\"hmac-sha256\"," +


### PR DESCRIPTION
This is a fix for #41.

When the signing algorithm is set to 'hs2019', the value of the 'algorithm' field in the **Authorization** header must be set to **hs2019**. Previously it was set to the actual cryptographic algorithm, such as rsa-sha256. When the signing algorithm is something other than  'hs2019', the value of the 'algorithm' field remains as it was before.

Example:
```
Signature keyId="my-key",algorithm="hs2019",\
headers="(request-target) host date digest content-length", \
signature="q2ctRkTYo6RRi7Tb7+C6nfYFRV+P2mw5ykEEdB0vQlcqF4pXqnWKjGI3ZBkrb7qKDxEE/zvrZKDsY3WUAS+UFvinhEwZUap4W3Xi4xwm4R7Wd9Gzm4l6SJf7I+UqhW0FjlH9i1/c+xpLFOY0puw1XIdVOBKS3UqxOpeY/0qdlkM="
```

versus:
```
Signature keyId="my-key",algorithm="rsa-sh256",\
headers="(request-target) host date digest content-length",\
signature="q2ctRkTYo6RRi7Tb7+C6nfYFRV+P2mw5ykEEdB0vQlcqF4pXqnWKjGI3ZBkrb7qKDxEE/zvrZKDsY3WUAS+UFvinhEwZUap4W3Xi4xwm4R7Wd9Gzm4l6SJf7I+UqhW0FjlH9i1/c+xpLFOY0puw1XIdVOBKS3UqxOpeY/0qdlkM="
```