### PR TITLE
Issue #29 Add signing algorithms

### DIFF
--- a/src/main/java/org/tomitribe/auth/signatures/Algorithm.java
+++ b/src/main/java/org/tomitribe/auth/signatures/Algorithm.java
@@ -38,6 +38,10 @@ public enum Algorithm {
     RSA_SHA384("SHA384withRSA", "rsa-sha384", java.security.Signature.class),
     RSA_SHA512("SHA512withRSA", "rsa-sha512", java.security.Signature.class),
 
+    RSA_SHA3_256("SHA3-256withRSA", "rsa-sha3-256", java.security.Signature.class),
+    RSA_SHA3_384("SHA3-384withRSA", "rsa-sha3-384", java.security.Signature.class),
+    RSA_SHA3_512("SHA3-512withRSA", "rsa-sha3-512", java.security.Signature.class),
+
     // RSA PSS signature
     // This algorithm requires parameter. For example:
     // new PSSParameterSpec("SHA-256", "MGF1", MGF1ParameterSpec.SHA256, 32, 1)
@@ -47,12 +51,33 @@ public enum Algorithm {
     DSA_SHA1("SHA1withDSA", "dsa-sha1", java.security.Signature.class),
     DSA_SHA224("SHA224withDSA", "dsa-sha224", java.security.Signature.class),
     DSA_SHA256("SHA256withDSA", "dsa-sha256", java.security.Signature.class),
+    DSA_SHA384("SHA384withDSA", "dsa-sha384", java.security.Signature.class),
+    DSA_SHA512("SHA512withDSA", "dsa-sha512", java.security.Signature.class),
 
-    // ecc
+    // dsa with SHA3
+    DSA_SHA3_256("SHA3-256withDSA", "dsa-sha3-256", java.security.Signature.class),
+    DSA_SHA3_384("SHA3-384withDSA", "dsa-sha3-384", java.security.Signature.class),
+    DSA_SHA3_512("SHA3-512withDSA", "dsa-sha3-512", java.security.Signature.class),
+
+    // ecdsa
     ECDSA_SHA1("SHA1withECDSA", "ecdsa-sha1", java.security.Signature.class),
     ECDSA_SHA256("SHA256withECDSA", "ecdsa-sha256", java.security.Signature.class),
     ECDSA_SHA384("SHA384withECDSA", "ecdsa-sha384", java.security.Signature.class),
     ECDSA_SHA512("SHA512withECDSA", "ecdsa-sha512", java.security.Signature.class),
+
+    // ecdsa with SHA3
+    ECDSA_SHA3_256("SHA3-256withECDSA", "ecdsa-sha3-256", java.security.Signature.class),
+    ECDSA_SHA3_384("SHA3-384withECDSA", "ecdsa-sha3-384", java.security.Signature.class),
+    ECDSA_SHA3_512("SHA3-512withECDSA", "ecdsa-sha3-512", java.security.Signature.class),
+
+    // ecdsa in P1363 Format.
+    // The ECDSA signature algorithms as defined in ANSI X9.62 with an output as
+    // defined in IEEE P1363 format. The format of the Signature bytes for these
+    // algorithms is an ASN.1 encoded sequence of the integers r and s:
+    //   SEQUENCE ::= { r INTEGER, s INTEGER }
+    ECDSA_SHA256_P1363("SHA256withECDSAinP1363Format", "ecdsa-sha256-p1363", java.security.Signature.class),
+    ECDSA_SHA384_P1363("SHA384withECDSAinP1363Format", "ecdsa-sha384-p1363", java.security.Signature.class),
+    ECDSA_SHA512_P1363("SHA512withECDSAinP1363Format", "ecdsa-sha512-p1363", java.security.Signature.class),
     ;
 
     private static final Map<String, Algorithm> aliases = new HashMap<String, Algorithm>();

--- a/src/main/java/org/tomitribe/auth/signatures/Algorithm.java
+++ b/src/main/java/org/tomitribe/auth/signatures/Algorithm.java
@@ -60,6 +60,8 @@ public enum Algorithm {
     DSA_SHA3_512("SHA3-512withDSA", "dsa-sha3-512", java.security.Signature.class),
 
     // ecdsa
+    // The format of the Signature bytes for these algorithms is an ASN.1 encoded
+    // sequence as specified in RFC 3279 section 2.2.2.
     ECDSA_SHA1("SHA1withECDSA", "ecdsa-sha1", java.security.Signature.class),
     ECDSA_SHA256("SHA256withECDSA", "ecdsa-sha256", java.security.Signature.class),
     ECDSA_SHA384("SHA384withECDSA", "ecdsa-sha384", java.security.Signature.class),
@@ -72,9 +74,8 @@ public enum Algorithm {
 
     // ecdsa in P1363 Format.
     // The ECDSA signature algorithms as defined in ANSI X9.62 with an output as
-    // defined in IEEE P1363 format. The format of the Signature bytes for these
-    // algorithms is an ASN.1 encoded sequence of the integers r and s:
-    //   SEQUENCE ::= { r INTEGER, s INTEGER }
+    // defined in IEEE P1363 format.
+    // The signature is the raw concatenation of r and s.
     ECDSA_SHA256_P1363("SHA256withECDSAinP1363Format", "ecdsa-sha256-p1363", java.security.Signature.class),
     ECDSA_SHA384_P1363("SHA384withECDSAinP1363Format", "ecdsa-sha384-p1363", java.security.Signature.class),
     ECDSA_SHA512_P1363("SHA512withECDSAinP1363Format", "ecdsa-sha512-p1363", java.security.Signature.class),

--- a/src/test/java/org/tomitribe/auth/signatures/AlgorithmTest.java
+++ b/src/test/java/org/tomitribe/auth/signatures/AlgorithmTest.java
@@ -34,14 +34,28 @@ public class AlgorithmTest extends Assert {
         assertEquals("rsa-sha256", RSA_SHA256.getPortableName());
         assertEquals("rsa-sha384", RSA_SHA384.getPortableName());
         assertEquals("rsa-sha512", RSA_SHA512.getPortableName());
+        assertEquals("rsa-sha3-256", RSA_SHA3_256.getPortableName());
+        assertEquals("rsa-sha3-384", RSA_SHA3_384.getPortableName());
+        assertEquals("rsa-sha3-512", RSA_SHA3_512.getPortableName());
         assertEquals("rsassa-pss", RSA_PSS.getPortableName());
         assertEquals("dsa-sha1", DSA_SHA1.getPortableName());
         assertEquals("dsa-sha224", DSA_SHA224.getPortableName());
         assertEquals("dsa-sha256", DSA_SHA256.getPortableName());
+        assertEquals("dsa-sha384", DSA_SHA384.getPortableName());
+        assertEquals("dsa-sha512", DSA_SHA512.getPortableName());
+        assertEquals("dsa-sha3-256", DSA_SHA3_256.getPortableName());
+        assertEquals("dsa-sha3-384", DSA_SHA3_384.getPortableName());
+        assertEquals("dsa-sha3-512", DSA_SHA3_512.getPortableName());
         assertEquals("ecdsa-sha1", ECDSA_SHA1.getPortableName());
         assertEquals("ecdsa-sha256", ECDSA_SHA256.getPortableName());
         assertEquals("ecdsa-sha384", ECDSA_SHA384.getPortableName());
         assertEquals("ecdsa-sha512", ECDSA_SHA512.getPortableName());
+        assertEquals("ecdsa-sha3-256", ECDSA_SHA3_256.getPortableName());
+        assertEquals("ecdsa-sha3-384", ECDSA_SHA3_384.getPortableName());
+        assertEquals("ecdsa-sha3-512", ECDSA_SHA3_512.getPortableName());
+        assertEquals("ecdsa-sha256-p1363", ECDSA_SHA256_P1363.getPortableName());
+        assertEquals("ecdsa-sha384-p1363", ECDSA_SHA384_P1363.getPortableName());
+        assertEquals("ecdsa-sha512-p1363", ECDSA_SHA512_P1363.getPortableName());
     }
 
     @Test
@@ -55,14 +69,25 @@ public class AlgorithmTest extends Assert {
         assertEquals("SHA256withRSA", RSA_SHA256.getJvmName());
         assertEquals("SHA384withRSA", RSA_SHA384.getJvmName());
         assertEquals("SHA512withRSA", RSA_SHA512.getJvmName());
+        assertEquals("SHA3-256withRSA", RSA_SHA3_256.getJvmName());
+        assertEquals("SHA3-384withRSA", RSA_SHA3_384.getJvmName());
+        assertEquals("SHA3-512withRSA", RSA_SHA3_512.getJvmName());
         assertEquals("RSASSA-PSS", RSA_PSS.getJvmName());
         assertEquals("SHA1withDSA", DSA_SHA1.getJvmName());
         assertEquals("SHA224withDSA", DSA_SHA224.getJvmName());
         assertEquals("SHA256withDSA", DSA_SHA256.getJvmName());
+        assertEquals("SHA384withDSA", DSA_SHA384.getJvmName());
+        assertEquals("SHA512withDSA", DSA_SHA512.getJvmName());
         assertEquals("SHA1withECDSA", ECDSA_SHA1.getJvmName());
         assertEquals("SHA256withECDSA", ECDSA_SHA256.getJvmName());
         assertEquals("SHA384withECDSA", ECDSA_SHA384.getJvmName());
         assertEquals("SHA512withECDSA", ECDSA_SHA512.getJvmName());
+        assertEquals("SHA3-256withECDSA", ECDSA_SHA3_256.getJvmName());
+        assertEquals("SHA3-384withECDSA", ECDSA_SHA3_384.getJvmName());
+        assertEquals("SHA3-512withECDSA", ECDSA_SHA3_512.getJvmName());
+        assertEquals("SHA256withECDSAinP1363Format", ECDSA_SHA256_P1363.getJvmName());
+        assertEquals("SHA384withECDSAinP1363Format", ECDSA_SHA384_P1363.getJvmName());
+        assertEquals("SHA512withECDSAinP1363Format", ECDSA_SHA512_P1363.getJvmName());
     }
 
     @Test

--- a/src/test/java/org/tomitribe/auth/signatures/EcTest.java
+++ b/src/test/java/org/tomitribe/auth/signatures/EcTest.java
@@ -130,6 +130,28 @@ public class EcTest extends Assert {
                 , "(request-target)", "host", "date");
     }
 
+    @Test
+    public void ecdsaSha256_P1363() throws Exception {
+        final Algorithm algorithm = Algorithm.ECDSA_SHA256_P1363;
+        String signature = generateSignature(algorithm, "date");
+        verifySignature(algorithm, signature, true, "date");
+    }
+
+
+    @Test
+    public void ecdsaSha384_P1363() throws Exception {
+        final Algorithm algorithm = Algorithm.ECDSA_SHA384_P1363;
+        String signature = generateSignature(algorithm, "date");
+        verifySignature(algorithm, signature, true, "date");
+    }
+
+    @Test
+    public void ecdsaSha512_P1363() throws Exception {
+        final Algorithm algorithm = Algorithm.ECDSA_SHA512_P1363;
+        String signature = generateSignature(algorithm, "date");
+        verifySignature(algorithm, signature, true, "date");
+    }
+
     private void assertSignature(final Algorithm algorithm, final String expected, final String... sign) throws Exception {
         String generated = generateSignature(algorithm, sign);
 


### PR DESCRIPTION
Add support for the following cryptographic algorithms:
1. SHA256withECDSAinP1363Format
1. SHA384withECDSAinP1363Format
1. SHA512withECDSAinP1363Format
1. SHA3-256withRSA
1. SHA3-384withRSA
1. SHA3-512withRSA
1. SHA384withDSA
1. SHA512withDSA
1. SHA3-256withDSA
1. SHA3-384withDSA
1. SHA3-512withDSA
1. SHA3-256withECDSA
1. SHA3-384withECDSA
1. SHA3-512withECDSA