### PR TITLE
Issue #40 Add support for '(created)' and '(expires)' fields

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 
   <artifactId>tomitribe-http-signatures</artifactId>
   <packaging>jar</packaging>
-  <version>1.6-SNAPSHOT</version>
+  <version>1.5-SNAPSHOT</version>
   <name>Tomitribe :: HTTP Signatures</name>
 
   <scm>
@@ -72,13 +72,6 @@
       <version>4.11</version>
       <scope>test</scope>
     </dependency>
-    <dependency>
-        <groupId>org.bouncycastle</groupId>
-        <artifactId>bcpkix-jdk15on</artifactId>
-        <version>1.65</version>
-        <!--<scope>test</scope> -->
-    </dependency>
   </dependencies>
-
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 
   <artifactId>tomitribe-http-signatures</artifactId>
   <packaging>jar</packaging>
-  <version>1.5-SNAPSHOT</version>
+  <version>1.6-SNAPSHOT</version>
   <name>Tomitribe :: HTTP Signatures</name>
 
   <scm>
@@ -72,6 +72,13 @@
       <version>4.11</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+        <groupId>org.bouncycastle</groupId>
+        <artifactId>bcpkix-jdk15on</artifactId>
+        <version>1.65</version>
+        <!--<scope>test</scope> -->
+    </dependency>
   </dependencies>
+
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.11</version>
+      <version>4.13</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/main/java/org/tomitribe/auth/signatures/InvalidCreatedFieldException.java
+++ b/src/main/java/org/tomitribe/auth/signatures/InvalidCreatedFieldException.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.tomitribe.auth.signatures;
+
+public class InvalidCreatedFieldException extends AuthenticationException {
+    public InvalidCreatedFieldException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/org/tomitribe/auth/signatures/InvalidExpiresFieldException.java
+++ b/src/main/java/org/tomitribe/auth/signatures/InvalidExpiresFieldException.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.tomitribe.auth.signatures;
+
+public class InvalidExpiresFieldException extends AuthenticationException {
+    public InvalidExpiresFieldException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/org/tomitribe/auth/signatures/Signature.java
+++ b/src/main/java/org/tomitribe/auth/signatures/Signature.java
@@ -121,14 +121,12 @@ public class Signature {
      * 
      * @param keyId An opaque string that the server can use to look up the component they need to validate the signature.
      * @param signingAlgorithm An identifier for the HTTP Signature algorithm.
-     *  This should be "hs2019" except for legacy applications that use an older version of the draft HTTP signature
-     *                         specification.
+     *  This should be "hs2019" except for legacy applications that use an older version of the draft HTTP signature specification.
      * @param algorithm The detailed algorithm used to sign the message.
      * @param parameterSpec optional cryptographic parameters for the signature.
      * @param headers The list of HTTP headers that will be used in the signature.
      */
-    public Signature(final String keyId, final String signingAlgorithm, final String algorithm,
-            final AlgorithmParameterSpec parameterSpec, final List<String> headers) {
+    public Signature(final String keyId, final String signingAlgorithm, final String algorithm, final AlgorithmParameterSpec parameterSpec, final List<String> headers) {
         this(keyId, getSigningAlgorithm(signingAlgorithm), getAlgorithm(algorithm), parameterSpec, null, headers);
     }
 

--- a/src/main/java/org/tomitribe/auth/signatures/Signature.java
+++ b/src/main/java/org/tomitribe/auth/signatures/Signature.java
@@ -421,50 +421,50 @@ public class Signature {
             }
 
             final List<String> headers = new ArrayList<String>();
-            FieldValue fv = map.get("headers");
-            if (fv != null) {
-                if (!fv.isString()) {
+            FieldValue fieldValue = map.get("headers");
+            if (fieldValue != null) {
+                if (!fieldValue.isString()) {
                     throw new IllegalArgumentException("headers field must be a double-quoted string");
                 }
-                Collections.addAll(headers, fv.getValueAsString().toLowerCase().split(" +"));
+                Collections.addAll(headers, fieldValue.getValueAsString().toLowerCase().split(" +"));
             }
 
             String keyid = null;
-            fv = map.get("keyid");
-            if (fv != null && fv.isString()) {
-                keyid = fv.getValueAsString();
+            fieldValue = map.get("keyid");
+            if (fieldValue != null && fieldValue.isString()) {
+                keyid = fieldValue.getValueAsString();
             }
             if (keyid == null) throw new MissingKeyIdException();
 
             String algorithmField = null;
-            fv = map.get("algorithm");
-            if (fv != null && fv.isString()) {
-                algorithmField = fv.getValueAsString();
+            fieldValue = map.get("algorithm");
+            if (fieldValue != null && fieldValue.isString()) {
+                algorithmField = fieldValue.getValueAsString();
             }
             if (algorithmField == null) throw new MissingAlgorithmException();
 
             String signature = null;
-            fv = map.get("signature");
-            if (fv != null && fv.isString()) {
-                signature = fv.getValueAsString();
+            fieldValue = map.get("signature");
+            if (fieldValue != null && fieldValue.isString()) {
+                signature = fieldValue.getValueAsString();
             }
             if (signature == null) throw new MissingSignatureException();
 
             Long created = null; // The signature creation time, in milliseconds since the epoch.
-            fv = map.get("created");
-            if (fv != null) {
-                if (!fv.isInteger()) {
+            fieldValue = map.get("created");
+            if (fieldValue != null) {
+                if (!fieldValue.isInteger()) {
                     throw new InvalidCreatedFieldException("Field must be an integer value");
                 }
-                created = fv.getValueAsLong() * 1000L;
+                created = fieldValue.getValueAsLong() * 1000L;
             }
             Long expires = null; // The signature expiration time, in milliseconds since the epoch.
-            fv = map.get("expires");
-            if (fv != null) {
-                if (!fv.isNumber()) {
+            fieldValue = map.get("expires");
+            if (fieldValue != null) {
+                if (!fieldValue.isNumber()) {
                     throw new InvalidExpiresFieldException("Field must be a number");
                 }
-                expires = (long)(fv.getValueAsDouble() * 1000L);
+                expires = (long)(fieldValue.getValueAsDouble() * 1000L);
             }
             SigningAlgorithm parsedSigningAlgorithm = null;
             try {

--- a/src/main/java/org/tomitribe/auth/signatures/Signature.java
+++ b/src/main/java/org/tomitribe/auth/signatures/Signature.java
@@ -516,11 +516,21 @@ public class Signature {
 
     @Override
     public String toString() {
+        Object alg;
+        if (SigningAlgorithm.HS2019.equals(signingAlgorithm)) {
+            // When the signing algorithm is set to 'hs2019', the value of the algorithm
+            // field must be set to 'hs2019'. The specific crypto algorithm is not
+            // serialized in the 'Authorization' header, the server must derive the value
+            // from the keyId.
+            alg = signingAlgorithm;
+        } else {
+            alg = algorithm;
+        }
         return "Signature " +
                 "keyId=\"" + keyId + '\"' +
                 (signatureCreatedTime != null ? String.format(",created=%d", signatureCreatedTime / 1000L) : "") +
                 (signatureExpiresTime != null ? String.format(",expires=%.3f", signatureExpiresTime / 1000.0) : "") +
-                ",algorithm=\"" + algorithm + '\"' +
+                ",algorithm=\"" + alg + '\"' +
                 ",headers=\"" + Join.join(" ", headers) + '\"' +
                 ",signature=\"" + signature + '\"';
     }

--- a/src/main/java/org/tomitribe/auth/signatures/Signature.java
+++ b/src/main/java/org/tomitribe/auth/signatures/Signature.java
@@ -32,7 +32,7 @@ public class Signature {
 
     /**
      * REQUIRED.  The `keyId` field is an opaque string that the server can
-     * use to look up the component they need to validate the signature. It
+     * use to look up the component they need to validate the signature.  It
      * could be an SSH key fingerprint, a URL to machine-readable key data,
      * an LDAP DN, etc.  Management of keys and assignment of `keyId` is out
      * of scope for this document.
@@ -66,24 +66,26 @@ public class Signature {
     private final Algorithm algorithm;
 
     /**
-     * REQUIRED. The `signature` parameter is a base 64 encoded digital signature,
-     * as described in RFC 4648 [RFC4648], Section 4 [4]. The client uses the
-     * `algorithm` and `headers` signature parameters to form a canonicalized
-     * `signing string`. This `signing string` is then signed with the key
-     * associated with `keyId` and the algorithm corresponding to `algorithm`. The
-     * `signature` parameter is then set to the base 64 encoding of the signature.
+     * REQUIRED. The `signature` parameter is a base 64 encoded digital
+     * signature, as described in RFC 4648 [RFC4648], Section 4 [4].  The
+     * client uses the `algorithm` and `headers` signature parameters to
+     * form a canonicalized `signing string`. This `signing string` is then
+     * signed with the key associated with `keyId` and the algorithm
+     * corresponding to `algorithm`. The `signature` parameter is then set
+     * to the base 64 encoding of the signature.
      */
     private final String signature;
 
     /**
      * OPTIONAL. The `headers` parameter is used to specify the list of HTTP headers
-     * included when generating the signature for the message. If specified, it
-     * should be a lowercased, quoted list of HTTP header fields, separated by a
-     * single space character. If not specified, implementations MUST operate as if
-     * the field were specified with a single value, the `Date` header, in the list
-     * of HTTP headers. Note that the list order is important, and MUST be specified
-     * in the order the HTTP header field-value pairs are concatenated together
-     * during signing.
+     * included when generating the signature for the message.
+     * If specified, it should be a lowercased, quoted list of HTTP header
+     * fields, separated by a single space character. If not specified,
+     * implementations MUST operate as if the field were specified with
+     * a single value, the `Date` header, in the list of HTTP headers. Note
+     * that the list order is important, and MUST be specified in the order
+     * the HTTP header field-value pairs are concatenated together during
+     * signing.
      */
     private final List<String> headers;
 

--- a/src/main/java/org/tomitribe/auth/signatures/Signature.java
+++ b/src/main/java/org/tomitribe/auth/signatures/Signature.java
@@ -31,20 +31,20 @@ import java.text.ParseException;
 public class Signature {
 
     /**
-     * REQUIRED. The `keyId` field is an opaque string that the server can use to
-     * look up the component they need to validate the signature. It could be an SSH
-     * key fingerprint, a URL to machine-readable key data, an LDAP DN, etc.
-     * Management of keys and assignment of `keyId` is out of scope for this
-     * document.
+     * REQUIRED. The `keyId` field is an opaque string that the server can
+     * use to look up the component they need to validate the signature. It
+     * could be an SSH key fingerprint, a URL to machine-readable key data,
+     * an LDAP DN, etc. Management of keys and assignment of `keyId` is out
+     * of scope for this document.
      */
     private final String keyId;
 
     /**
      * RECOMMENDED. The `signingAlgorithm` parameter is used to specify the digital
-     * signature algorithm to use when generating the signature. Valid values for
-     * this parameter can be found in the Signature Algorithms registry located at
-     * http://www.iana.org/assignments/signature- algorithms and MUST NOT be marked
-     * "deprecated".
+     * signature algorithm to use when generating the signature.  Valid
+     * values for this parameter can be found in the Signature Algorithms
+     * registry located at http://www.iana.org/assignments/signature-
+     * algorithms and MUST NOT be marked "deprecated".
      * 
      * Verifiers MUST determine the signature's Algorithm from the keyId parameter
      * rather than from algorithm. If algorithm is provided and differs from or is

--- a/src/main/java/org/tomitribe/auth/signatures/Signature.java
+++ b/src/main/java/org/tomitribe/auth/signatures/Signature.java
@@ -492,7 +492,7 @@ public class Signature {
                 parsedAlgorithm = algorithm;
             }
 
-            Signature s = new Signature(keyid, parsedSigningAlgorithm, parsedAlgorithm, null, signature, headers, null, created, expires);
+            final Signature s = new Signature(keyid, parsedSigningAlgorithm, parsedAlgorithm, null, signature, headers, null, created, expires);
             s.verifySignatureValidityDates();
             return s;
 

--- a/src/main/java/org/tomitribe/auth/signatures/Signature.java
+++ b/src/main/java/org/tomitribe/auth/signatures/Signature.java
@@ -74,6 +74,10 @@ public class Signature {
      * signed with the key associated with `keyId` and the algorithm
      * corresponding to `algorithm`.  The `signature` parameter is then set
      * to the base 64 encoding of the signature.
+     * 
+     * Signing: this field is calculated from the input data.
+     * Verification: this field is parsed from the signature field in the
+     * Authorization header.
      */
     private final String signature;
 

--- a/src/main/java/org/tomitribe/auth/signatures/Signature.java
+++ b/src/main/java/org/tomitribe/auth/signatures/Signature.java
@@ -236,8 +236,8 @@ public class Signature {
     }
 
     /**
-     * Returns the identifier for the HTTP Signature Algorithm, as registered in the
-     * HTTP Signature Algorithms Registry.
+     * Returns the identifier for the HTTP Signature Algorithm, as registered
+     * in the HTTP Signature Algorithms Registry.
      * 
      * @return the identifier for the HTTP Signature Algorithm.
      */
@@ -270,16 +270,13 @@ public class Signature {
     /**
      * Constructs a Signature object by parsing the 'Authorization' header.
      * 
-     * As stated in the HTTP signature specification, the value of the algorithm
-     * parameter in the 'Authorization' header should be set to generic identifier.
-     * The detailed algorithm should be derived from the keyId. Hence it is not
-     * possible to determine the detailed algorithm by inspecting the signature
-     * data.
+     * As stated in the HTTP signature specification, the value of the algorithm parameter in
+     * the 'Authorization' header should be set to generic identifier. The detailed algorithm
+     * should be derived from the keyId. Hence it is not possible to determine the detailed
+     * algorithm by inspecting the signature data.
      * 
-     * @param authorization The value of the HTTP 'Authorization' header containing
-     *                      the signature data.
-     * @param algorithm     The detailed cryptographic algorithm for the HTTP
-     *                      signature.
+     * @param authorization The value of the HTTP 'Authorization' header containing the signature data.
+     * @param algorithm The detailed cryptographic algorithm for the HTTP signature.
      * 
      * @return The Signature object.
      */

--- a/src/main/java/org/tomitribe/auth/signatures/Signature.java
+++ b/src/main/java/org/tomitribe/auth/signatures/Signature.java
@@ -66,23 +66,23 @@ public class Signature {
     private final Algorithm algorithm;
 
     /**
-     * REQUIRED. The `signature` parameter is a base 64 encoded digital
+     * REQUIRED.  The `signature` parameter is a base 64 encoded digital
      * signature, as described in RFC 4648 [RFC4648], Section 4 [4].  The
      * client uses the `algorithm` and `headers` signature parameters to
-     * form a canonicalized `signing string`. This `signing string` is then
+     * form a canonicalized `signing string`.  This `signing string` is then
      * signed with the key associated with `keyId` and the algorithm
-     * corresponding to `algorithm`. The `signature` parameter is then set
+     * corresponding to `algorithm`.  The `signature` parameter is then set
      * to the base 64 encoding of the signature.
      */
     private final String signature;
 
     /**
-     * OPTIONAL. The `headers` parameter is used to specify the list of HTTP headers
-     * included when generating the signature for the message.
+     * OPTIONAL. The `headers` parameter is used to specify the list of
+     * HTTP headers included when generating the signature for the message.
      * If specified, it should be a lowercased, quoted list of HTTP header
      * fields, separated by a single space character. If not specified,
-     * implementations MUST operate as if the field were specified with
-     * a single value, the `Date` header, in the list of HTTP headers. Note
+     * implementations MUST operate as if the field were specified with a
+     * single value, the `Date` header, in the list of HTTP headers.  Note
      * that the list order is important, and MUST be specified in the order
      * the HTTP header field-value pairs are concatenated together during
      * signing.

--- a/src/main/java/org/tomitribe/auth/signatures/Signature.java
+++ b/src/main/java/org/tomitribe/auth/signatures/Signature.java
@@ -107,6 +107,11 @@ public class Signature {
      */
     private Double signatureExpirationTime;
 
+    /**
+     * Regular expression pattern for fields present in the Authorization field.
+     * Fields value may be double-quoted strings, e.g. algorithm="hs2019"
+     * Some fields may be numerical values without double-quotes, e.g. created=123456
+     */
     private static final Pattern RFC_2617_PARAM = Pattern
             .compile("(?<key>\\w+)=((\"(?<stringValue>[^\"]*)\")|(?<numberValue>\\d+\\.?\\d*))");
 

--- a/src/main/java/org/tomitribe/auth/signatures/Signature.java
+++ b/src/main/java/org/tomitribe/auth/signatures/Signature.java
@@ -117,19 +117,15 @@ public class Signature {
     public static long maxTimeSkewInSeconds = 30;
 
     /**
-     * Construct a signature configuration instance with the specified keyId,
-     * algorithm and HTTP headers.
+     * Construct a signature configuration instance with the specified keyId, algorithm and HTTP headers.
      * 
-     * @param keyId            An opaque string that the server can use to look up
-     *                         the component they need to validate the signature.
-     * @param signingAlgorithm An identifier for the HTTP Signature algorithm. This
-     *                         should be "hs2019" except for legacy applications
-     *                         that use an older version of the draft HTTP signature
+     * @param keyId An opaque string that the server can use to look up the component they need to validate the signature.
+     * @param signingAlgorithm An identifier for the HTTP Signature algorithm.
+     *  This should be "hs2019" except for legacy applications that use an older version of the draft HTTP signature
      *                         specification.
-     * @param algorithm        The detailed algorithm used to sign the message.
-     * @param parameterSpec    optional cryptographic parameters for the signature.
-     * @param headers          The list of HTTP headers that will be used in the
-     *                         signature.
+     * @param algorithm The detailed algorithm used to sign the message.
+     * @param parameterSpec optional cryptographic parameters for the signature.
+     * @param headers The list of HTTP headers that will be used in the signature.
      */
     public Signature(final String keyId, final String signingAlgorithm, final String algorithm,
             final AlgorithmParameterSpec parameterSpec, final List<String> headers) {

--- a/src/main/java/org/tomitribe/auth/signatures/Signature.java
+++ b/src/main/java/org/tomitribe/auth/signatures/Signature.java
@@ -31,12 +31,6 @@ import java.text.ParseException;
 public class Signature {
 
     /**
-     * The maximum time skew between the client and the server.
-     * This is used to validate the (created) and (expires) fields in the HTTP signature.
-     */
-    public static long maxTimeSkewInSeconds = 30;
-
-    /**
      * REQUIRED. The `keyId` field is an opaque string that the server can use to
      * look up the component they need to validate the signature. It could be an SSH
      * key fingerprint, a URL to machine-readable key data, an LDAP DN, etc.
@@ -113,6 +107,12 @@ public class Signature {
 
     private static final Pattern RFC_2617_PARAM = Pattern
             .compile("(?<key>\\w+)=((\"(?<stringValue>[^\"]*)\")|(?<numberValue>\\d+\\.?\\d*))");
+
+    /**
+     * The maximum time skew between the client and the server.
+     * This is used to validate the (created) and (expires) fields in the HTTP signature.
+     */
+    public static long maxTimeSkewInSeconds = 30;
 
     /**
      * Construct a signature configuration instance with the specified keyId,

--- a/src/main/java/org/tomitribe/auth/signatures/Signature.java
+++ b/src/main/java/org/tomitribe/auth/signatures/Signature.java
@@ -94,6 +94,12 @@ public class Signature {
      */
     private final AlgorithmParameterSpec parameterSpec;
 
+    /**
+     * OPTIONAL. The duration of the signature validity. If set, this is
+     * used to calculate the '(expires)' field in the HTTP signature.
+     */
+    private Double signatureValidity;
+
     private static final Pattern RFC_2617_PARAM = Pattern.compile("(\\w+)=\"([^\"]*)\"");
 
     /**
@@ -156,6 +162,23 @@ public class Signature {
         } else {
             this.headers = Collections.unmodifiableList(lowercase(headers));
         }
+    }
+
+    /**
+     * Sets the signature validity, in seconds.
+     */
+    public Signature signatureValidity(Double signatureValidity) {
+        this.signatureValidity = signatureValidity;
+        return this;
+    }
+
+    /**
+     * Returns the value of the signature validity, in seconds.
+     * 
+     * @return the value of the signature validity, in seconds.
+     */
+    public Double getSignatureValidity() {
+        return signatureValidity;
     }
 
     private List<String> lowercase(List<String> headers) {

--- a/src/main/java/org/tomitribe/auth/signatures/Signature.java
+++ b/src/main/java/org/tomitribe/auth/signatures/Signature.java
@@ -103,6 +103,9 @@ public class Signature {
 
     /**
      * OPTIONAL. The configurable signature's maximum validation duration, in milliseconds.
+     * This field is applicable when the signed headers include '(expires)'.
+     * In that case, the value of the '(expires)' field is calculated by adding
+     * maxSignatureValidityDuration to the timestamp of the signature creation time.
      * 
      * This field is used to derive the signature expiration time when a cryptographic signature
      * is generated.

--- a/src/main/java/org/tomitribe/auth/signatures/Signature.java
+++ b/src/main/java/org/tomitribe/auth/signatures/Signature.java
@@ -77,10 +77,10 @@ public class Signature {
     private final String signature;
 
     /**
-     * OPTIONAL. The `headers` parameter is used to specify the list of
+     * OPTIONAL.  The `headers` parameter is used to specify the list of
      * HTTP headers included when generating the signature for the message.
      * If specified, it should be a lowercased, quoted list of HTTP header
-     * fields, separated by a single space character. If not specified,
+     * fields, separated by a single space character.  If not specified,
      * implementations MUST operate as if the field were specified with a
      * single value, the `Date` header, in the list of HTTP headers.  Note
      * that the list order is important, and MUST be specified in the order
@@ -91,7 +91,7 @@ public class Signature {
 
     /**
      * OPTIONAL.  The `parameterSpec` is used to specify the cryptographic
-     * parameters. Some cryptographic algorithm such as RSASSA-PSS
+     * parameters. Some cryptographic algorithm such as RSASSA-PSS 
      * require parameters.
      */
     private final AlgorithmParameterSpec parameterSpec;

--- a/src/main/java/org/tomitribe/auth/signatures/Signature.java
+++ b/src/main/java/org/tomitribe/auth/signatures/Signature.java
@@ -513,13 +513,12 @@ public class Signature {
 
     @Override
     public String toString() {
-        String s = "Signature " +
+        return "Signature " +
                 "keyId=\"" + keyId + '\"' +
                 (signatureCreatedTime != null ? String.format(",created=%d", signatureCreatedTime / 1000L) : "") +
                 (signatureExpiresTime != null ? String.format(",expires=%.3f", signatureExpiresTime / 1000.0) : "") +
                 ",algorithm=\"" + algorithm + '\"' +
                 ",headers=\"" + Join.join(" ", headers) + '\"' +
                 ",signature=\"" + signature + '\"';
-        return s;
     }
 }

--- a/src/main/java/org/tomitribe/auth/signatures/Signature.java
+++ b/src/main/java/org/tomitribe/auth/signatures/Signature.java
@@ -143,22 +143,23 @@ public class Signature {
     }
 
     public Signature(final String keyId, final String signingAlgorithm, final String algorithm,
-            final AlgorithmParameterSpec parameterSpec, final String signature, final List<String> headers) {
+                        final AlgorithmParameterSpec parameterSpec, final String signature, final List<String> headers) {
         this(keyId, getSigningAlgorithm(signingAlgorithm), getAlgorithm(algorithm), parameterSpec, signature, headers);
     }
 
     public Signature(final String keyId, final SigningAlgorithm signingAlgorithm, final Algorithm algorithm,
-            final AlgorithmParameterSpec parameterSpec, final String signature, final List<String> headers) {
+                        final AlgorithmParameterSpec parameterSpec, final String signature, final List<String> headers) {
         if (keyId == null || keyId.trim().isEmpty()) {
             throw new IllegalArgumentException("keyId is required.");
         }
         if (algorithm == null) {
             throw new IllegalArgumentException("algorithm is required.");
         }
-        if (signingAlgorithm != null && signingAlgorithm.getSupportedAlgorithms() != null
-                && !signingAlgorithm.getSupportedAlgorithms().contains(algorithm)) {
-            throw new IllegalArgumentException("Signing algorithm " + signingAlgorithm.getAlgorithmName()
-                    + " is not compatible with " + algorithm.getPortableName());
+        if (signingAlgorithm != null &&
+            signingAlgorithm.getSupportedAlgorithms() != null &&
+            !signingAlgorithm.getSupportedAlgorithms().contains(algorithm)) {
+            throw new IllegalArgumentException("Signing algorithm " + signingAlgorithm.getAlgorithmName() +
+                                                " is not compatible with " + algorithm.getPortableName());
         }
 
         this.keyId = keyId;

--- a/src/main/java/org/tomitribe/auth/signatures/Signature.java
+++ b/src/main/java/org/tomitribe/auth/signatures/Signature.java
@@ -31,37 +31,37 @@ import java.text.ParseException;
 public class Signature {
 
     /**
-     * REQUIRED. The `keyId` field is an opaque string that the server can
+     * REQUIRED.  The `keyId` field is an opaque string that the server can
      * use to look up the component they need to validate the signature. It
      * could be an SSH key fingerprint, a URL to machine-readable key data,
-     * an LDAP DN, etc. Management of keys and assignment of `keyId` is out
+     * an LDAP DN, etc.  Management of keys and assignment of `keyId` is out
      * of scope for this document.
      */
     private final String keyId;
 
     /**
-     * RECOMMENDED. The `signingAlgorithm` parameter is used to specify the digital
+     * RECOMMENDED.  The `signingAlgorithm` parameter is used to specify the digital
      * signature algorithm to use when generating the signature.  Valid
      * values for this parameter can be found in the Signature Algorithms
      * registry located at http://www.iana.org/assignments/signature-
      * algorithms and MUST NOT be marked "deprecated".
      * 
      * Verifiers MUST determine the signature's Algorithm from the keyId parameter
-     * rather than from algorithm. If algorithm is provided and differs from or is
-     * incompatible with the algorithm or key material identified by keyId (for
-     * example, algorithm has a value of rsa-sha256 but keyId identifies an EdDSA
-     * key), then implementations MUST produce an error.
+     * rather than from algorithm. If algorithm is provided and differs from or
+     * is incompatible with the algorithm or key material identified by keyId
+     * (for example, algorithm has a value of rsa-sha256 but keyId identifies
+     * an EdDSA key), then implementations MUST produce an error.
      * 
      * https://datatracker.ietf.org/doc/draft-ietf-httpbis-message-signatures/
      */
     private final SigningAlgorithm signingAlgorithm;
 
     /**
-     * REQUIRED. The `algorithm` parameter is used to specify the digital signature
-     * algorithm to use when generating the signature. Valid values for this
-     * parameter can be found in the Signature Algorithms registry located at
-     * http://www.iana.org/assignments/signature- algorithms and MUST NOT be marked
-     * "deprecated".
+     * REQUIRED.  The `algorithm` parameter is used to specify the digital
+     * signature algorithm to use when generating the signature.  Valid
+     * values for this parameter can be found in the Signature Algorithms
+     * registry located at http://www.iana.org/assignments/signature-
+     * algorithms and MUST NOT be marked "deprecated".
      */
     private final Algorithm algorithm;
 
@@ -88,9 +88,9 @@ public class Signature {
     private final List<String> headers;
 
     /**
-     * OPTIONAL. The `parameterSpec` is used to specify the cryptographic
-     * parameters. Some cryptographic algorithm such as RSASSA-PSS require
-     * parameters.
+     * OPTIONAL.  The `parameterSpec` is used to specify the cryptographic
+     * parameters. Some cryptographic algorithm such as RSASSA-PSS
+     * require parameters.
      */
     private final AlgorithmParameterSpec parameterSpec;
 

--- a/src/main/java/org/tomitribe/auth/signatures/Signature.java
+++ b/src/main/java/org/tomitribe/auth/signatures/Signature.java
@@ -131,14 +131,12 @@ public class Signature {
     }
 
     private static Algorithm getAlgorithm(String algorithm) {
-        if (algorithm == null)
-            throw new IllegalArgumentException("Algorithm cannot be null");
+        if (algorithm == null) throw new IllegalArgumentException("Algorithm cannot be null");
         return Algorithm.get(algorithm);
     }
 
     private static SigningAlgorithm getSigningAlgorithm(String scheme) {
-        if (scheme == null)
-            throw new IllegalArgumentException("Signing scheme cannot be null");
+        if (scheme == null) throw new IllegalArgumentException("Signing scheme cannot be null");
         return SigningAlgorithm.get(scheme);
     }
 

--- a/src/main/java/org/tomitribe/auth/signatures/Signatures.java
+++ b/src/main/java/org/tomitribe/auth/signatures/Signatures.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 public enum Signatures {
     ;
@@ -69,7 +70,7 @@ public enum Signatures {
                 if (signatureCreationTime == null) {
                     throw new InvalidCreatedFieldException("(created) field requested but signature creation time is not set");
                 }
-                list.add(key + ": " + Long.toString(signatureCreationTime / 1000L));
+                list.add(key + ": " + Long.toString(TimeUnit.MILLISECONDS.toSeconds(signatureCreationTime)));
             } else if ("(expires)".equals(key)) {
                 // The "expires" parameter contains the signature's Expiration Time.
                 // If the signature does not have an Expiration Time, this parameter "MUST"

--- a/src/main/java/org/tomitribe/auth/signatures/Signatures.java
+++ b/src/main/java/org/tomitribe/auth/signatures/Signatures.java
@@ -42,9 +42,14 @@ public enum Signatures {
      * Create a canonicalized string representation of the HTTP request. It is used
      * as the input to calculate the signature of the HTTP request.
      * 
+     * The provided method, path and query values are used to generate the optional
+     * (request-target) field.
+     * 
      * @param required The list of headers that should be included in the HTTP signature.
      * @param method The HTTP method.
-     * @param uri The HTTP request URI.
+     * @param uri The path and query of the request target of the message.
+     *            The value must already be encoded exactly as it will be sent in the
+     *            request line of the HTTP message. No URL encoding is performed by this method.
      * @param headers A map of header names to header values.
      * @param signatureCreationTime The signature creation time in milliseconds since the epoch.
      * @param signatureExpiryTime The signature expiration time in milliseconds since the epoch.

--- a/src/main/java/org/tomitribe/auth/signatures/Signer.java
+++ b/src/main/java/org/tomitribe/auth/signatures/Signer.java
@@ -98,10 +98,9 @@ public class Signer {
 
         final String signedAndEncodedString = new String(encoded, "UTF-8");
 
-        Signature s = new Signature(signature.getKeyId(), signature.getSigningAlgorithm(),
+        return new Signature(signature.getKeyId(), signature.getSigningAlgorithm(),
                              signature.getAlgorithm(), signature.getParameterSpec(),
                              signedAndEncodedString, signature.getHeaders(), null, created, expires);
-        return s;
     }
 
     /**

--- a/src/main/java/org/tomitribe/auth/signatures/Signer.java
+++ b/src/main/java/org/tomitribe/auth/signatures/Signer.java
@@ -100,7 +100,7 @@ public class Signer {
     }
 
     public String createSigningString(final String method, final String uri, final Map<String, String> headers) throws IOException {
-        return Signatures.createSigningString(signature.getHeaders(), method, uri, headers);
+        return Signatures.createSigningString(signature.getHeaders(), method, uri, headers, signature.getSignatureValidity());
     }
 
     private interface Sign {

--- a/src/main/java/org/tomitribe/auth/signatures/Signer.java
+++ b/src/main/java/org/tomitribe/auth/signatures/Signer.java
@@ -85,7 +85,7 @@ public class Signer {
     }
 
     public Signature sign(final String method, final String uri, final Map<String, String> headers) throws IOException {
-        Long created = System.currentTimeMillis();
+        final Long created = System.currentTimeMillis();
         Long expires = signature.getSignatureMaxValidityMilliseconds();
         if (expires != null) {
             expires += created;

--- a/src/main/java/org/tomitribe/auth/signatures/Signer.java
+++ b/src/main/java/org/tomitribe/auth/signatures/Signer.java
@@ -84,6 +84,17 @@ public class Signer {
         }
     }
 
+    /**
+     * Create and return a HTTP signature object.
+     * 
+     * @param method The HTTP method.
+     * @param uri The path and query of the request target of the message.
+     *            The value must already be encoded exactly as it will be sent in the
+     *            request line of the HTTP message. No URL encoding is performed by this method.
+     * @param headers The HTTP headers.
+     * 
+     * @return a Signature object containing the signed message.
+     */
     public Signature sign(final String method, final String uri, final Map<String, String> headers) throws IOException {
         final Long created = System.currentTimeMillis();
         Long expires = signature.getSignatureMaxValidityMilliseconds();
@@ -107,7 +118,9 @@ public class Signer {
      * Create and return the string which is used as input for the cryptographic signature.
      * 
      * @param method The HTTP method.
-     * @param uri The URI path and query parameters.
+     * @param uri The path and query of the request target of the message.
+     *            The value must already be encoded exactly as it will be sent in the
+     *            request line of the HTTP message. No URL encoding is performed by this method.
      * @param headers The HTTP headers.
      * @param created The time when the signature is created.
      * @param expires The time when the signature expires.

--- a/src/main/java/org/tomitribe/auth/signatures/Signer.java
+++ b/src/main/java/org/tomitribe/auth/signatures/Signer.java
@@ -100,7 +100,7 @@ public class Signer {
     }
 
     public String createSigningString(final String method, final String uri, final Map<String, String> headers) throws IOException {
-        return Signatures.createSigningString(signature.getHeaders(), method, uri, headers, signature.getSignatureValidity());
+        return Signatures.createSigningString(signature.getHeaders(), method, uri, headers, signature.getSignatureExpirationTime());
     }
 
     private interface Sign {

--- a/src/main/java/org/tomitribe/auth/signatures/Verifier.java
+++ b/src/main/java/org/tomitribe/auth/signatures/Verifier.java
@@ -83,11 +83,7 @@ public class Verifier {
     }
 
     public boolean verify(final String method, final String uri, final Map<String, String> headers) throws IOException, NoSuchAlgorithmException, SignatureException {
-        try {
-            signature.verifySignatureValidityDates();
-        } catch (Exception e) {
-            return false;
-        }
+        signature.verifySignatureValidityDates();
         final String signingString = createSigningString(method, uri, headers);
 
         return verify.verify(signingString.getBytes());

--- a/src/main/java/org/tomitribe/auth/signatures/Verifier.java
+++ b/src/main/java/org/tomitribe/auth/signatures/Verifier.java
@@ -90,7 +90,7 @@ public class Verifier {
     }
 
     public String createSigningString(final String method, final String uri, final Map<String, String> headers) throws IOException {
-        return Signatures.createSigningString(signature.getHeaders(), method, uri, headers, signature.getSignatureValidity());
+        return Signatures.createSigningString(signature.getHeaders(), method, uri, headers, signature.getSignatureExpirationTime());
     }
 
     private interface Verify {

--- a/src/main/java/org/tomitribe/auth/signatures/Verifier.java
+++ b/src/main/java/org/tomitribe/auth/signatures/Verifier.java
@@ -83,14 +83,20 @@ public class Verifier {
     }
 
     public boolean verify(final String method, final String uri, final Map<String, String> headers) throws IOException, NoSuchAlgorithmException, SignatureException {
-
+        try {
+            signature.verifySignatureValidityDates();
+        } catch (Exception e) {
+            return false;
+        }
         final String signingString = createSigningString(method, uri, headers);
 
         return verify.verify(signingString.getBytes());
     }
 
     public String createSigningString(final String method, final String uri, final Map<String, String> headers) throws IOException {
-        return Signatures.createSigningString(signature.getHeaders(), method, uri, headers, signature.getSignatureExpirationTime());
+        return Signatures.createSigningString(signature.getHeaders(), method, uri, headers,
+            signature.getSignatureCreationTimeMilliseconds(),
+            signature.getSignatureExpirationTimeMilliseconds());
     }
 
     private interface Verify {

--- a/src/main/java/org/tomitribe/auth/signatures/Verifier.java
+++ b/src/main/java/org/tomitribe/auth/signatures/Verifier.java
@@ -90,7 +90,7 @@ public class Verifier {
     }
 
     public String createSigningString(final String method, final String uri, final Map<String, String> headers) throws IOException {
-        return Signatures.createSigningString(signature.getHeaders(), method, uri, headers);
+        return Signatures.createSigningString(signature.getHeaders(), method, uri, headers, signature.getSignatureValidity());
     }
 
     private interface Verify {

--- a/src/test/java/org/tomitribe/auth/signatures/AlgorithmTest.java
+++ b/src/test/java/org/tomitribe/auth/signatures/AlgorithmTest.java
@@ -102,4 +102,12 @@ public class AlgorithmTest extends Assert {
     public void unsupportedAlgorithmException() throws Exception {
         Algorithm.get("HmacMD256");
     }
+
+    @Test
+    public void getSigningAlgorithm() throws Exception {
+        for (final SigningAlgorithm algorithm : SigningAlgorithm.values()) {
+            SigningAlgorithm s = SigningAlgorithm.get(algorithm.getAlgorithmName());
+            assertEquals(algorithm, s);
+        }
+    }    
 }

--- a/src/test/java/org/tomitribe/auth/signatures/RsaTest.java
+++ b/src/test/java/org/tomitribe/auth/signatures/RsaTest.java
@@ -28,8 +28,6 @@ import java.util.Map;
 import java.security.spec.AlgorithmParameterSpec;
 import java.security.spec.PSSParameterSpec;
 import java.security.spec.MGF1ParameterSpec;
-import javax.crypto.spec.SecretKeySpec;
-import java.security.Key;
 
 public class RsaTest extends Assert {
 

--- a/src/test/java/org/tomitribe/auth/signatures/SignatureTest.java
+++ b/src/test/java/org/tomitribe/auth/signatures/SignatureTest.java
@@ -231,7 +231,7 @@ public class SignatureTest {
 
     @Test
     public void nullHeaders() {
-        final Signature signature = new Signature("somekey", SigningAlgorithm.HS2019.getAlgorithmName(), "hmac-sha256", null, "yT/NrPI9mKB5R7FTLRyFWvB+QLQOEAvbGmauC0tI+Jg=", Arrays.asList());
+        final Signature signature = new Signature("somekey", SigningAlgorithm.HMAC_SHA256.getAlgorithmName(), "hmac-sha256", null, "yT/NrPI9mKB5R7FTLRyFWvB+QLQOEAvbGmauC0tI+Jg=", Arrays.asList());
         assertEquals(1, signature.getHeaders().size()); // should contain at least the Date which is required
         assertEquals("date", signature.getHeaders().get(0).toLowerCase());
     }
@@ -239,7 +239,7 @@ public class SignatureTest {
 
     @Test
     public void roundTripTest() throws Exception {
-        final Signature expected = new Signature("somekey", SigningAlgorithm.HS2019.getAlgorithmName(), "hmac-sha256", null, "yT/NrPI9mKB5R7FTLRyFWvB+QLQOEAvbGmauC0tI+Jg=", Arrays.asList("date", "accept"));
+        final Signature expected = new Signature("somekey", SigningAlgorithm.HMAC_SHA256.getAlgorithmName(), "hmac-sha256", null, "yT/NrPI9mKB5R7FTLRyFWvB+QLQOEAvbGmauC0tI+Jg=", Arrays.asList("date", "accept"));
         final Signature actual = Signature.fromString(expected.toString(), null);
 
         assertSignature(expected, actual);
@@ -405,7 +405,7 @@ public class SignatureTest {
     @Test
     public void orderTolerance() throws Exception {
 
-        final Signature expected = new Signature("hmac-key-1", SigningAlgorithm.HS2019.getAlgorithmName(), "hmac-sha256", null, "yT/NrPI9mKB5R7FTLRyFWvB+QLQOEAvbGmauC0tI+Jg=", Arrays.asList("date", "accept"));
+        final Signature expected = new Signature("hmac-key-1", SigningAlgorithm.HMAC_SHA256.getAlgorithmName(), "hmac-sha256", null, "yT/NrPI9mKB5R7FTLRyFWvB+QLQOEAvbGmauC0tI+Jg=", Arrays.asList("date", "accept"));
 
         final List<String> input = Arrays.asList(
                 "keyId=\"hmac-key-1\"",
@@ -430,7 +430,7 @@ public class SignatureTest {
     @Test
     public void caseNormalization() throws Exception {
 
-        final Signature signature = new Signature("hmac-key-1", SigningAlgorithm.HS2019.getAlgorithmName(), "hMaC-ShA256", null, "yT/NrPI9mKB5R7FTLRyFWvB+QLQOEAvbGmauC0tI+Jg=", Arrays.asList("dAte", "aCcEpt"));
+        final Signature signature = new Signature("hmac-key-1", SigningAlgorithm.HMAC_SHA256.getAlgorithmName(), "hMaC-ShA256", null, "yT/NrPI9mKB5R7FTLRyFWvB+QLQOEAvbGmauC0tI+Jg=", Arrays.asList("dAte", "aCcEpt"));
 
         assertEquals("hmac-key-1", signature.getKeyId());
         assertEquals("hmac-sha256", signature.getAlgorithm().toString());
@@ -527,7 +527,7 @@ public class SignatureTest {
     @Test
     public void testToString() throws Exception {
 
-        final Signature signature = new Signature("hmac-key-1", SigningAlgorithm.HS2019.getAlgorithmName(), "hmac-sha256", null, "Base64(HMAC-SHA256(signing string))", Arrays.asList("(request-target)", "host", "date", "digest", "content-length"));
+        final Signature signature = new Signature("hmac-key-1", SigningAlgorithm.HMAC_SHA256.getAlgorithmName(), "hmac-sha256", null, "Base64(HMAC-SHA256(signing string))", Arrays.asList("(request-target)", "host", "date", "digest", "content-length"));
 
         String authorization = "Signature keyId=\"hmac-key-1\"," +
                 "algorithm=\"hmac-sha256\"," +

--- a/src/test/java/org/tomitribe/auth/signatures/SignatureTest.java
+++ b/src/test/java/org/tomitribe/auth/signatures/SignatureTest.java
@@ -54,6 +54,147 @@ public class SignatureTest {
         new Signature("somekey", null, "hmac-sha256", null, "yT/NrPI9mKB5R7FTLRyFWvB+QLQOEAvbGmauC0tI+Jg=", Arrays.asList("date", "accept"));
     }
 
+    /**
+     * Invalid (created) field, the value must be a number, not a string.
+     */
+    @Test(expected = InvalidCreatedFieldException.class)
+    public void signatureCreatedFieldAsString() throws Exception {
+        String authorization = "Signature keyId=\"hmac-key-1\",algorithm=\"hmac-sha256\"," +
+                "created=\"1591763110\"," +
+                "headers=\"(created)\"" +
+                ",signature=\"Base64(HMAC-SHA256(signing string))\"";
+        Signature.fromString(authorization, null);
+    }
+
+
+    /**
+     * The signature is invalid because the (created) field is in the future.
+     */
+    @Test(expected = InvalidCreatedFieldException.class)
+    public void signatureCreatedInTheFuture() throws Exception {
+        long created = (System.currentTimeMillis() / 1000L) + 3600;
+        String authorization = String.format("Signature keyId=\"hmac-key-1\",algorithm=\"hmac-sha256\"," +
+                "created=%d," +
+                "headers=\"(created)\"" +
+                ",signature=\"Base64(HMAC-SHA256(signing string))\"", created);
+        Signature.fromString(authorization, null);
+    }
+
+    /**
+     * The signature is invalid because the (expires) field is in the past.
+     */
+    @Test(expected = InvalidExpiresFieldException.class)
+    public void signatureExpiresInThePast() throws Exception {
+        double expires = (System.currentTimeMillis() / 1000.0) - 3600;
+        String authorization = String.format("Signature keyId=\"hmac-key-1\",algorithm=\"hmac-sha256\"," +
+                "expires=%f," +
+                "headers=\"(expires)\"" +
+                ",signature=\"Base64(HMAC-SHA256(signing string))\"", expires);
+        Signature.fromString(authorization, null);
+    }
+
+    /**
+     * The signature has been created slightly in the future.
+     * In practice, this is most likely due to a time skew between the client and server.
+     */
+    @Test
+    public void signatureCreatedSlightlyInTheFuture() throws Exception {
+        long created = (System.currentTimeMillis() / 1000L) + 5;
+        String authorization = String.format("Signature keyId=\"hmac-key-1\",algorithm=\"hmac-sha256\"," +
+                "created=%d," +
+                "headers=\"(created)\"" +
+                ",signature=\"Base64(HMAC-SHA256(signing string))\"", created);
+        Signature.fromString(authorization, null);
+    }
+
+    /**
+     * Invalid (created) field, the value must be a number, not a string.
+     */
+    @Test(expected = InvalidCreatedFieldException.class)
+    public void signatureCreatedFieldIntegerTooLarge() throws Exception {
+        String authorization = "Signature keyId=\"hmac-key-1\",algorithm=\"hmac-sha256\"," +
+                "created=15917631101724387234723847238492374892374283947289472398472834," +
+                "headers=\"(created)\"" +
+                ",signature=\"Base64(HMAC-SHA256(signing string))\"";
+        Signature.fromString(authorization, null);
+    }
+
+    /**
+     * Invalid (created) field, the value must be an integer, decimal values are not supported.
+     */
+    @Test(expected = InvalidCreatedFieldException.class)
+    public void signatureCreatedFieldDecimalValue() throws Exception {
+        String authorization = "Signature keyId=\"hmac-key-1\",algorithm=\"hmac-sha256\"," +
+                "created=1591763110.123," +
+                "headers=\"(created)\"" +
+                ",signature=\"Base64(HMAC-SHA256(signing string))\"";
+        Signature.fromString(authorization, null);
+    }
+
+    /**
+     * Invalid (expires) field, the value must be a number, not a string.
+     */
+    @Test(expected = InvalidExpiresFieldException.class)
+    public void signatureExpiresFieldAsString() throws Exception {
+        String authorization = "Signature keyId=\"hmac-key-1\",algorithm=\"hmac-sha256\"," +
+                "expires=\"159176.3110\"," +
+                "headers=\"(expires)\"" +
+                ",signature=\"Base64(HMAC-SHA256(signing string))\"";
+        Signature.fromString(authorization, null);
+    }
+
+    /**
+     * Invalid (expires) field, the value must be a parseable number
+     */
+    @Test(expected = InvalidExpiresFieldException.class)
+    public void signatureExpiresFieldInvalidNumber() throws Exception {
+        String authorization = "Signature keyId=\"hmac-key-1\",algorithm=\"hmac-sha256\"," +
+                "expires=\"159176..3110\"," +
+                "headers=\"(expires)\"" +
+                ",signature=\"Base64(HMAC-SHA256(signing string))\"";
+        Signature.fromString(authorization, null);
+    }
+
+    /**
+     * Invalid keyId field, the value must be a double-quoted string.
+     */
+    @Test(expected = MissingKeyIdException.class)
+    public void signatureInvalidKeyIdFormat() throws Exception {
+        String authorization = "Signature keyId=hmac-key-1,algorithm=\"hmac-sha256\"," +
+                ",signature=\"Base64(HMAC-SHA256(signing string))\"";
+        Signature.fromString(authorization, null);
+    }
+
+    /**
+     * Invalid keyId field, the value must be a double-quoted string, not a number.
+     */
+    @Test(expected = MissingKeyIdException.class)
+    public void signatureInvalidKeyIdFormatNumberr() throws Exception {
+        String authorization = "Signature keyId=1123,algorithm=\"hmac-sha256\"," +
+                ",signature=\"Base64(HMAC-SHA256(signing string))\"";
+        Signature.fromString(authorization, null);
+    }
+    
+    /**
+     * Invalid algorithm field, the value must be a double-quoted string.
+     */
+    @Test(expected = MissingAlgorithmException.class)
+    public void signatureInvalidAlgorithmFormat() throws Exception {
+        String authorization = "Signature keyId=\"hmac-key-1\",algorithm=256," +
+                ",signature=\"Base64(HMAC-SHA256(signing string))\"";
+        Signature.fromString(authorization, null);
+    }
+
+    /**
+     * Invalid signature field, the value must be a double-quoted string.
+     */
+    @Test(expected = MissingSignatureException.class)
+    public void signatureInvalidSignatureFormat() throws Exception {
+        String authorization = "Signature keyId=\"hmac-key-1\",algorithm=\"hmac-sha256\"," +
+                ",signature=1234";
+        Signature.fromString(authorization, null);
+    }
+    
     @Test
     public void nullHeaders() {
         final Signature signature = new Signature("somekey", SigningAlgorithm.HS2019.getAlgorithmName(), "hmac-sha256", null, "yT/NrPI9mKB5R7FTLRyFWvB+QLQOEAvbGmauC0tI+Jg=", Arrays.asList());
@@ -158,6 +299,33 @@ public class SignatureTest {
                 "four\n" +
                 "five\n" +
                 "six", join("\n", signature.getHeaders()));
+    }
+
+    /**
+     * Signature validity fields (created) and (expires).
+     */
+    @Test
+    public void signatureCreatedAndExpiresFields() throws Exception {
+        long created = System.currentTimeMillis() / 1000L;
+        double expires = System.currentTimeMillis() / 1000.0 + 3600;
+        String authorization = String.format("Signature keyId=\"hmac-key-1\",algorithm=\"hmac-sha256\"," +
+                "created=%d,expires=%f," +
+                "headers=\"(request-target) (created) (expires) one two\"" +
+                ",signature=\"Base64(HMAC-SHA256(signing string))\"", created, expires);
+
+        final Signature signature = Signature.fromString(authorization, null);
+
+        assertEquals("hmac-key-1", signature.getKeyId());
+        assertEquals("hmac-sha256", signature.getAlgorithm().toString());
+        assertEquals("Base64(HMAC-SHA256(signing string))", signature.getSignature());
+        assertEquals(
+                "(request-target)\n" +
+                "(created)\n" +
+                "(expires)\n" +
+                "one\n" +
+                "two", join("\n", signature.getHeaders()));
+        assertEquals((Long)created, signature.getSignatureCreationTime());
+        assertEquals((Double)expires, signature.getSignatureExpirationTime());
     }
 
     @Test

--- a/src/test/java/org/tomitribe/auth/signatures/VerifierTest.java
+++ b/src/test/java/org/tomitribe/auth/signatures/VerifierTest.java
@@ -19,7 +19,6 @@ package org.tomitribe.auth.signatures;
 import org.junit.Assert;
 import org.junit.Test;
 
-import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 import java.security.Key;
 import java.security.Provider;

--- a/src/test/java/org/tomitribe/auth/signatures/VerifierTest.java
+++ b/src/test/java/org/tomitribe/auth/signatures/VerifierTest.java
@@ -171,9 +171,13 @@ public class VerifierTest extends Assert {
         boolean verifies = verifier.verify("GET", "/foo/Bar", headers);
         assertTrue(verifies);
 
+        // Sleep a bit, this will cause the signature to expire, then verify
+        // the signature again, this time it should fail.
         Thread.sleep(maxValidity);
-        verifies = verifier.verify("GET", "/foo/Bar", headers);
-        assertFalse(verifies);
+        Exception exception = assertThrows(InvalidExpiresFieldException.class, () -> {
+            verifier.verify("GET", "/foo/Bar", headers);
+        });
+        assertEquals("Signature has expired", exception.getMessage());
     }
 
     /**

--- a/src/test/java/org/tomitribe/auth/signatures/VerifierTest.java
+++ b/src/test/java/org/tomitribe/auth/signatures/VerifierTest.java
@@ -161,7 +161,7 @@ public class VerifierTest extends Assert {
         assertTrue(authorization.contains("expires="));
 
         // Assert the signature verification.
-        final Signature parsedSignature = Signature.fromString(authorization, null);
+        final Signature parsedSignature = Signature.fromString(authorization, Algorithm.HMAC_SHA256);
         assertNotNull(parsedSignature.getSignatureCreationTimeMilliseconds());
         assertNotNull(parsedSignature.getSignatureExpirationTimeMilliseconds());
         assertNotNull(parsedSignature.getSignatureCreation());


### PR DESCRIPTION
This is a fix for #40: add support `(created)` and `(expires)` fields as specified in https://tools.ietf.org/html/draft-ietf-httpbis-message-signatures-00

#36 needs to be merged before this PR, and after merging there will be a small merge conflict that I will need to resolve.