### PR TITLE
fix pattern and toString, then enhance sign() method

### DIFF
--- a/src/main/java/org/tomitribe/auth/signatures/Signer.java
+++ b/src/main/java/org/tomitribe/auth/signatures/Signer.java
@@ -85,22 +85,21 @@ public class Signer {
     }
 
     /**
-     * Create and return a HTTP signature object.
+     * Create and return a HTTP signature object configured with 'created' and 'expires' values.
+     * Useful if you want to recreate a Signature from configuration to validate another one.
      *
      * @param method The HTTP method.
      * @param uri The path and query of the request target of the message.
      *            The value must already be encoded exactly as it will be sent in the
      *            request line of the HTTP message. No URL encoding is performed by this method.
      * @param headers The HTTP headers.
+     * @param created the created timestamp
+     * @param expires the expires timestamp
      *
      * @return a Signature object containing the signed message.
      */
-    public Signature sign(final String method, final String uri, final Map<String, String> headers) throws IOException {
-        final Long created = System.currentTimeMillis();
-        Long expires = signature.getSignatureMaxValidityMilliseconds();
-        if (expires != null) {
-            expires += created;
-        }
+    public Signature sign(final String method, final String uri, final Map<String, String> headers, Long created, Long expires) throws IOException {
+
         final String signingString = createSigningString(method, uri, headers, created, expires);
 
         final byte[] binarySignature = sign.sign(signingString.getBytes("UTF-8"));
@@ -112,6 +111,26 @@ public class Signer {
         return new Signature(signature.getKeyId(), signature.getSigningAlgorithm(),
                 signature.getAlgorithm(), signature.getParameterSpec(),
                 signedAndEncodedString, signature.getHeaders(), null, created, expires);
+    }
+
+    /**
+     * Create and return a HTTP signature object.
+     *
+     * @param method The HTTP method.
+     * @param uri The path and query of the request target of the message.
+     *            The value must already be encoded exactly as it will be sent in the
+     *            request line of the HTTP message. No URL encoding is performed by this method.
+     * @param headers The HTTP headers.
+     *
+     * @return a Signature object containing the signed message.
+     */
+    public Signature sign(final String method, final String uri, final Map<String, String> headers) throws IOException {
+        final long created = System.currentTimeMillis();
+        Long expires = signature.getSignatureMaxValidityMilliseconds();
+        if (expires != null) {
+            expires += created;
+        }
+        return sign(method, uri, headers, created, expires);
     }
 
     /**

--- a/src/test/java/org/tomitribe/auth/signatures/SignatureTest.java
+++ b/src/test/java/org/tomitribe/auth/signatures/SignatureTest.java
@@ -21,6 +21,7 @@ import org.junit.Test;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Random;
 
 import static org.junit.Assert.assertEquals;
@@ -121,11 +122,27 @@ public class SignatureTest {
 
     /**
      * Invalid (created) field, the value must be an integer, decimal values are not supported.
+     * Locale EN
      */
     @Test(expected = InvalidCreatedFieldException.class)
-    public void signatureCreatedFieldDecimalValue() throws Exception {
+    public void signatureCreatedFieldDecimalValueEN() throws Exception {
+        Locale.setDefault(Locale.ENGLISH);
         final String authorization = "Signature keyId=\"hmac-key-1\",algorithm=\"hmac-sha256\"," +
                 "created=1591763110.123," +
+                "headers=\"(created)\"" +
+                ",signature=\"Base64(HMAC-SHA256(signing string))\"";
+        Signature.fromString(authorization, null);
+    }
+
+    /**
+     * Invalid (created) field, the value must be an integer, decimal values are not supported.
+     * Locale FR
+     */
+    @Test(expected = InvalidCreatedFieldException.class)
+    public void signatureCreatedFieldDecimalValueFR() throws Exception {
+        Locale.setDefault(Locale.FRENCH);
+        final String authorization = "Signature keyId=\"hmac-key-1\",algorithm=\"hmac-sha256\"," +
+                "created=1591763110,123," +
                 "headers=\"(created)\"" +
                 ",signature=\"Base64(HMAC-SHA256(signing string))\"";
         Signature.fromString(authorization, null);

--- a/src/test/java/org/tomitribe/auth/signatures/SignerTest.java
+++ b/src/test/java/org/tomitribe/auth/signatures/SignerTest.java
@@ -109,7 +109,7 @@ public class SignerTest extends Assert {
             headers.put("Content-Length", "18");
             final Signature signed = signer.sign(method, uri, headers);
             assertEquals("yT/NrPI9mKB5R7FTLRyFWvB+QLQOEAvbGmauC0tI+Jg=", signed.getSignature());
-            assertToString("Signature keyId=\"hmac-key-1\",created=9999,algorithm=\"hs2019\"," +
+            assertToString("Signature keyId=\"hmac-key-1\",algorithm=\"hs2019\"," +
                     "headers=\"content-length host date (request-target)\",signature=\"yT/NrPI9mKB5R7FTLRyFWvB+QLQOEAvbGmauC0tI+Jg=\"", signed);
         }
 
@@ -125,7 +125,7 @@ public class SignerTest extends Assert {
             headers.put("Content-Length", "18");
             final Signature signed = signer.sign(method, uri, headers);
             assertEquals("DPIsA/PWeYjySmfjw2P2SLJXZj1szDOei/Hh8nTcaPo=", signed.getSignature());
-            assertToString("Signature keyId=\"hmac-key-1\",created=9999,algorithm=\"hs2019\"," +
+            assertToString("Signature keyId=\"hmac-key-1\",algorithm=\"hs2019\"," +
                     "headers=\"content-length host date (request-target)\",signature=\"DPIsA/PWeYjySmfjw2P2SLJXZj1szDOei/Hh8nTcaPo=\"", signed);
         }
 
@@ -141,7 +141,7 @@ public class SignerTest extends Assert {
             headers.put("Content-Length", "18");
             final Signature signed = signer.sign(method, uri, headers);
             assertEquals("DPIsA/PWeYjySmfjw2P2SLJXZj1szDOei/Hh8nTcaPo=", signed.getSignature());
-            assertToString("Signature keyId=\"hmac-key-1\",created=1628283435,algorithm=\"hs2019\"," +
+            assertToString("Signature keyId=\"hmac-key-1\",algorithm=\"hs2019\"," +
                     "headers=\"content-length host date (request-target)\",signature=\"DPIsA/PWeYjySmfjw2P2SLJXZj1szDOei/Hh8nTcaPo=\"", signed);
         }
 
@@ -157,7 +157,7 @@ public class SignerTest extends Assert {
             headers.put("Content-Length", "18");
             final Signature signed = signer.sign(method, uri, headers);
             assertEquals("IWTDxmOoEJI67YxY3eDIRzxrsAtlYYCuGZxKlkUSYdA=", signed.getSignature());
-            assertToString("Signature keyId=\"hmac-key-1\",created=9999,algorithm=\"hs2019\"," +
+            assertToString("Signature keyId=\"hmac-key-1\",algorithm=\"hs2019\"," +
                     "headers=\"content-length host date (request-target)\",signature=\"IWTDxmOoEJI67YxY3eDIRzxrsAtlYYCuGZxKlkUSYdA=\"", signed);
         }
     }

--- a/src/test/java/org/tomitribe/auth/signatures/SignerWithAlgorithmTest.java
+++ b/src/test/java/org/tomitribe/auth/signatures/SignerWithAlgorithmTest.java
@@ -144,6 +144,113 @@ public class SignerWithAlgorithmTest extends Assert {
         }
     }
 
+    /**
+     * It is an intentional part of the design that the same Signer instance
+     * can be reused on several HTTP Messages in a multi-threaded fashion
+     * <p/>
+     * Reuse is tested here
+     * <p/>
+     */
+    @Test
+    public void testSignAtCreatedAndExpires() throws Exception {
+
+        final Signature signature = new Signature("hmac-key-1", "hmac-sha256", null, "content-length", "host", "date", "(request-target)");
+
+        final Key key = new SecretKeySpec("don't tell".getBytes(), "HmacSHA256");
+        final Signer signer = new Signer(key, signature);
+
+        final long created = 1631187000;
+        final long expires = 1631191300786L;
+
+        final String method = "GET";
+        final String uri = "/foo/Bar";
+        final Map<String, String> headers = new HashMap<String, String>();
+        headers.put("Host", "example.org");
+        headers.put("Date", "Tue, 07 Jun 2014 20:51:35 GMT");
+        headers.put("Content-Type", "application/json");
+        headers.put("Digest", "SHA-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=");
+        headers.put("Accept", "*/*");
+        headers.put("Content-Length", "18");
+        final Signature signed = signer.sign(method, uri, headers, created, expires);
+        assertEquals("yT/NrPI9mKB5R7FTLRyFWvB+QLQOEAvbGmauC0tI+Jg=", signed.getSignature());
+        assertEquals("Signature keyId=\"hmac-key-1\",algorithm=\"hmac-sha256\",headers=\"content-length host date (request-target)\",signature=\"yT/NrPI9mKB5R7FTLRyFWvB+QLQOEAvbGmauC0tI+Jg=\"", signed.toString());
+    }
+
+    @Test
+    public void testSignAtCreatedAndExpiresWithCreatedHeader() throws Exception {
+
+        final Signature signature = new Signature("hmac-key-1", "hmac-sha256", null, "content-length", "host", "date", "(request-target)", "(created)");
+
+        final Key key = new SecretKeySpec("don't tell".getBytes(), "HmacSHA256");
+        final Signer signer = new Signer(key, signature);
+
+        final long created = 1631187000;
+        final long expires = 1631191300786L;
+
+        final String method = "GET";
+        final String uri = "/foo/Bar";
+        final Map<String, String> headers = new HashMap<String, String>();
+        headers.put("Host", "example.org");
+        headers.put("Date", "Tue, 07 Jun 2014 20:51:35 GMT");
+        headers.put("Content-Type", "application/json");
+        headers.put("Digest", "SHA-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=");
+        headers.put("Accept", "*/*");
+        headers.put("Content-Length", "18");
+        final Signature signed = signer.sign(method, uri, headers, created, expires);
+        assertEquals("im9YJlYjVPwq0TIndq3mEUC6kH6LaMAZWG4hZ7hVYi4=", signed.getSignature());
+        assertEquals("Signature keyId=\"hmac-key-1\",created=1631187,algorithm=\"hmac-sha256\",headers=\"content-length host date (request-target) (created)\",signature=\"im9YJlYjVPwq0TIndq3mEUC6kH6LaMAZWG4hZ7hVYi4=\"", signed.toString());
+    }
+
+    @Test
+    public void testSignAtCreatedAndExpiresWithExpiresHeader() throws Exception {
+
+        final Signature signature = new Signature("hmac-key-1", "hmac-sha256", null, "content-length", "host", "date", "(request-target)", "(expires)");
+
+        final Key key = new SecretKeySpec("don't tell".getBytes(), "HmacSHA256");
+        final Signer signer = new Signer(key, signature);
+
+        final long created = 1631187000;
+        final long expires = 1631191300786L;
+
+        final String method = "GET";
+        final String uri = "/foo/Bar";
+        final Map<String, String> headers = new HashMap<String, String>();
+        headers.put("Host", "example.org");
+        headers.put("Date", "Tue, 07 Jun 2014 20:51:35 GMT");
+        headers.put("Content-Type", "application/json");
+        headers.put("Digest", "SHA-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=");
+        headers.put("Accept", "*/*");
+        headers.put("Content-Length", "18");
+        final Signature signed = signer.sign(method, uri, headers, created, expires);
+        assertEquals("wqu4SMw/Iqv8KMxqX18mWs6Zs94XFNXOU0Uh5tq23Zw=", signed.getSignature());
+        assertEquals("Signature keyId=\"hmac-key-1\",expires=1631191300,786,algorithm=\"hmac-sha256\",headers=\"content-length host date (request-target) (expires)\",signature=\"wqu4SMw/Iqv8KMxqX18mWs6Zs94XFNXOU0Uh5tq23Zw=\"", signed.toString());
+    }
+
+    @Test
+    public void testSignAtCreatedAndExpiresWithCreatedAndExpiresHeader() throws Exception {
+
+        final Signature signature = new Signature("hmac-key-1", "hmac-sha256", null, "content-length", "host", "date", "(request-target)", "(created)", "(expires)");
+
+        final Key key = new SecretKeySpec("don't tell".getBytes(), "HmacSHA256");
+        final Signer signer = new Signer(key, signature);
+
+        final long created = 1631187000;
+        final long expires = 1631191300786L;
+
+        final String method = "GET";
+        final String uri = "/foo/Bar";
+        final Map<String, String> headers = new HashMap<String, String>();
+        headers.put("Host", "example.org");
+        headers.put("Date", "Tue, 07 Jun 2014 20:51:35 GMT");
+        headers.put("Content-Type", "application/json");
+        headers.put("Digest", "SHA-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=");
+        headers.put("Accept", "*/*");
+        headers.put("Content-Length", "18");
+        final Signature signed = signer.sign(method, uri, headers, created, expires);
+        assertEquals("OVtTtYTcmKgjl7X5kSLT00pbbaOKluD6Gk1pluNBnsU=", signed.getSignature());
+        assertEquals("Signature keyId=\"hmac-key-1\",created=1631187,expires=1631191300,786,algorithm=\"hmac-sha256\",headers=\"content-length host date (request-target) (created) (expires)\",signature=\"OVtTtYTcmKgjl7X5kSLT00pbbaOKluD6Gk1pluNBnsU=\"", signed.toString());
+    }
+
     @Test
     public void defaultHeaderList() throws Exception {
         final Signature signature = new Signature("hmac-key-1", "hmac-sha256", null);


### PR DESCRIPTION
### Fix pattern

Fixing `RFC_2617_PARAM` to be able to parse timestamp with a `,` separated decimal part (for example, for french people)

### Fix Signature.toString()

I don't understand why `created` and `expires` disappeared from Signature string if algo is not HS2019.
What I propose is to only add those informations if not null and if headers contains `(created)` or `(expires)`

### Add a new Signer.sign() method

Create a new  `public Signature sign(final String method, final String uri, final Map<String, String> headers, Long created, Long expires) throws IOException`

The idea here is to provide a way to sign giving the choice of created and expires timestamp.
It is useful for a validation case from a string, you are able to regenerate a signature from input and keep control on those two timestamps.
