### PR TITLE
Fix #54: Improve testability

### DIFF
--- a/src/main/java/org/tomitribe/auth/signatures/Signer.java
+++ b/src/main/java/org/tomitribe/auth/signatures/Signer.java
@@ -22,6 +22,7 @@ import java.security.Key;
 import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
 import java.security.Provider;
+import java.time.Clock;
 import java.util.Map;
 
 import static java.util.Objects.requireNonNull;
@@ -45,16 +46,26 @@ public class Signer {
     private final Signature signature;
     private final Algorithm algorithm;
     private final Provider provider;
+    private final Clock clock;
 
     public Signer(final Key key, final Signature signature) {
-        this(key, signature, null);
+        this(key, signature, null, Clock.systemUTC());
     }
 
     public Signer(final Key key, final Signature signature, final Provider provider) {
+        this(key, signature, provider, Clock.systemUTC());
+    }
+
+    public Signer(final Key key, final Signature signature, final Clock clock) {
+        this(key, signature, null, clock);
+    }
+
+    public Signer(final Key key, final Signature signature, final Provider provider, Clock clock) {
         requireNonNull(key, "Key cannot be null");
         this.signature = requireNonNull(signature, "Signature cannot be null");
         this.algorithm = signature.getAlgorithm();
         this.provider = provider;
+        this.clock = requireNonNull(clock, "clock cannot be null");
 
         if (java.security.Signature.class.equals(algorithm.getType())) {
 
@@ -96,7 +107,7 @@ public class Signer {
      * @return a Signature object containing the signed message.
      */
     public Signature sign(final String method, final String uri, final Map<String, String> headers) throws IOException {
-        final Long created = System.currentTimeMillis();
+        final Long created = clock.millis();
         Long expires = signature.getSignatureMaxValidityMilliseconds();
         if (expires != null) {
             expires += created;

--- a/src/test/java/org/tomitribe/auth/signatures/SignatureTest.java
+++ b/src/test/java/org/tomitribe/auth/signatures/SignatureTest.java
@@ -46,7 +46,7 @@ public class SignatureTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void nullAlgorithm() {
-        new Signature("somekey", SigningAlgorithm.HS2019.getAlgorithmName(), (String) null, null, "yT/NrPI9mKB5R7FTLRyFWvB+QLQOEAvbGmauC0tI+Jg=", Arrays.asList("date", "accept"));
+        new Signature("somekey", SigningAlgorithm.HS2019.getAlgorithmName(), null, null, "yT/NrPI9mKB5R7FTLRyFWvB+QLQOEAvbGmauC0tI+Jg=", Arrays.asList("date", "accept"));
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -359,7 +359,7 @@ public class SignatureTest {
     @Test
     public void signatureCreatedAndExpiresFields() throws Exception {
         final long created = (System.currentTimeMillis() / 1000L) * 1000L;
-        final long expires = System.currentTimeMillis() + 3600L * 1000L;
+        final long expires = created + 3600L * 1000L;
         final String authorization = String.format("Signature keyId=\"hmac-key-1\",algorithm=\"hmac-sha256\"," +
                 "created=%d,expires=%f," +
                 "headers=\"(request-target) (created) (expires) one two\"" +

--- a/src/test/java/org/tomitribe/auth/signatures/SignerTest.java
+++ b/src/test/java/org/tomitribe/auth/signatures/SignerTest.java
@@ -24,6 +24,9 @@ import java.io.ByteArrayInputStream;
 import java.security.Key;
 import java.security.PrivateKey;
 import java.security.Provider;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -95,7 +98,7 @@ public class SignerTest extends Assert {
         final Signature signature = new Signature("hmac-key-1", SigningAlgorithm.HS2019.getAlgorithmName(), "hmac-sha256", null, null, Arrays.asList("content-length", "host", "date", "(request-target)"));
 
         final Key key = new SecretKeySpec("don't tell".getBytes(), "HmacSHA256");
-        final Signer signer = new Signer(key, signature);
+        final Signer signer = new Signer(key, signature, Clock.fixed(Instant.ofEpochMilli(123456789l), ZoneId.systemDefault()));
 
         {
             final String method = "GET";
@@ -109,8 +112,8 @@ public class SignerTest extends Assert {
             headers.put("Content-Length", "18");
             final Signature signed = signer.sign(method, uri, headers);
             assertEquals("yT/NrPI9mKB5R7FTLRyFWvB+QLQOEAvbGmauC0tI+Jg=", signed.getSignature());
-            assertToString("Signature keyId=\"hmac-key-1\",created=9999,algorithm=\"hs2019\"," +
-                    "headers=\"content-length host date (request-target)\",signature=\"yT/NrPI9mKB5R7FTLRyFWvB+QLQOEAvbGmauC0tI+Jg=\"", signed);
+            assertEquals("Signature keyId=\"hmac-key-1\",created=123456,algorithm=\"hs2019\"," +
+                        "headers=\"content-length host date (request-target)\",signature=\"yT/NrPI9mKB5R7FTLRyFWvB+QLQOEAvbGmauC0tI+Jg=\"", signed.toString());
         }
 
         { // method changed.  should get a different signature
@@ -125,8 +128,8 @@ public class SignerTest extends Assert {
             headers.put("Content-Length", "18");
             final Signature signed = signer.sign(method, uri, headers);
             assertEquals("DPIsA/PWeYjySmfjw2P2SLJXZj1szDOei/Hh8nTcaPo=", signed.getSignature());
-            assertToString("Signature keyId=\"hmac-key-1\",created=9999,algorithm=\"hs2019\"," +
-                    "headers=\"content-length host date (request-target)\",signature=\"DPIsA/PWeYjySmfjw2P2SLJXZj1szDOei/Hh8nTcaPo=\"", signed);
+            assertEquals("Signature keyId=\"hmac-key-1\",created=123456,algorithm=\"hs2019\"," +
+                        "headers=\"content-length host date (request-target)\",signature=\"DPIsA/PWeYjySmfjw2P2SLJXZj1szDOei/Hh8nTcaPo=\"", signed.toString());
         }
 
         { // only Digest changed.  not part of the signature, should have no effect
@@ -141,8 +144,8 @@ public class SignerTest extends Assert {
             headers.put("Content-Length", "18");
             final Signature signed = signer.sign(method, uri, headers);
             assertEquals("DPIsA/PWeYjySmfjw2P2SLJXZj1szDOei/Hh8nTcaPo=", signed.getSignature());
-            assertToString("Signature keyId=\"hmac-key-1\",created=1628283435,algorithm=\"hs2019\"," +
-                    "headers=\"content-length host date (request-target)\",signature=\"DPIsA/PWeYjySmfjw2P2SLJXZj1szDOei/Hh8nTcaPo=\"", signed);
+            assertEquals("Signature keyId=\"hmac-key-1\",created=123456,algorithm=\"hs2019\"," +
+                        "headers=\"content-length host date (request-target)\",signature=\"DPIsA/PWeYjySmfjw2P2SLJXZj1szDOei/Hh8nTcaPo=\"", signed.toString());
         }
 
         { // uri changed.  should get a different signature
@@ -157,17 +160,9 @@ public class SignerTest extends Assert {
             headers.put("Content-Length", "18");
             final Signature signed = signer.sign(method, uri, headers);
             assertEquals("IWTDxmOoEJI67YxY3eDIRzxrsAtlYYCuGZxKlkUSYdA=", signed.getSignature());
-            assertToString("Signature keyId=\"hmac-key-1\",created=9999,algorithm=\"hs2019\"," +
-                    "headers=\"content-length host date (request-target)\",signature=\"IWTDxmOoEJI67YxY3eDIRzxrsAtlYYCuGZxKlkUSYdA=\"", signed);
+            assertEquals("Signature keyId=\"hmac-key-1\",created=123456,algorithm=\"hs2019\"," +
+                        "headers=\"content-length host date (request-target)\",signature=\"IWTDxmOoEJI67YxY3eDIRzxrsAtlYYCuGZxKlkUSYdA=\"", signed.toString());
         }
-    }
-
-    private void assertToString(final String expected, final Signature signed) {
-        assertEquals(normalize(expected), normalize(signed.toString()));
-    }
-
-    private static String normalize(final String s) {
-        return s.replaceAll("(created)=[0-9]+", "$1=9999");
     }
 
     @Test


### PR DESCRIPTION
Improve testability of `Signer` and classes that depend on it by replacing use of `System.currentTimeMillis()` with `java.time.Clock`

Fix #54